### PR TITLE
fix: Separate network config classes for proper YAML override inheritance

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -9,7 +9,8 @@ Exported utilities:
     - KeysConfig: Pydantic model for Nostr key configuration
     - load_keys_from_env: Load Nostr keys from environment variables
     - NetworkConfig: Unified network configuration for all services
-    - NetworkTypeConfig: Settings for individual network types
+    - ClearnetConfig, TorConfig, I2pConfig, LokiConfig: Per-network configs
+    - NetworkTypeConfig: Type alias for any network-specific config
     - create_client: Factory for creating Nostr clients
     - load_yaml: Load YAML configuration files
     - parse_typed_dict: Type-safe parsing against TypedDict schemas
@@ -21,7 +22,14 @@ Example:
 """
 
 from utils.keys import KeysConfig, load_keys_from_env
-from utils.network import NetworkConfig, NetworkTypeConfig
+from utils.network import (
+    ClearnetConfig,
+    I2pConfig,
+    LokiConfig,
+    NetworkConfig,
+    NetworkTypeConfig,
+    TorConfig,
+)
 from utils.parsing import parse_typed_dict
 from utils.progress import BatchProgress
 from utils.transport import create_client
@@ -30,9 +38,13 @@ from utils.yaml import load_yaml
 
 __all__ = [
     "BatchProgress",
+    "ClearnetConfig",
+    "I2pConfig",
     "KeysConfig",
+    "LokiConfig",
     "NetworkConfig",
     "NetworkTypeConfig",
+    "TorConfig",
     "create_client",
     "load_keys_from_env",
     "load_yaml",

--- a/tests/unit/services/test_monitor.py
+++ b/tests/unit/services/test_monitor.py
@@ -29,7 +29,7 @@ from services.monitor import (
     ProfileConfig,
     PublishingConfig,
 )
-from utils.network import NetworkConfig, NetworkTypeConfig
+from utils.network import NetworkConfig, TorConfig
 
 
 # Valid secp256k1 test key (DO NOT USE IN PRODUCTION)
@@ -634,7 +634,7 @@ class TestMonitorInit:
     def test_init_with_custom_config(self, mock_brotr: Brotr, tmp_path: Path) -> None:
         """Test initialization with custom config."""
         config = MonitorConfig(
-            networks=NetworkConfig(tor=NetworkTypeConfig(enabled=False)),
+            networks=NetworkConfig(tor=TorConfig(enabled=False)),
             processing=ProcessingConfig(
                 compute=MetadataFlags(nip66_geo=False, nip66_net=False),
                 store=MetadataFlags(nip66_geo=False, nip66_net=False),

--- a/tests/unit/services/test_synchronizer.py
+++ b/tests/unit/services/test_synchronizer.py
@@ -28,7 +28,7 @@ from services.synchronizer import (
     SyncTimeoutsConfig,
     TimeRangeConfig,
 )
-from utils.network import NetworkConfig, NetworkTypeConfig
+from utils.network import NetworkConfig, TorConfig
 
 
 # Valid secp256k1 test key (DO NOT USE IN PRODUCTION)
@@ -291,7 +291,7 @@ class TestSynchronizerConfig:
     def test_custom_nested_config(self) -> None:
         """Test custom nested configuration with Tor enabled."""
         config = SynchronizerConfig(
-            networks=NetworkConfig(tor=NetworkTypeConfig(enabled=True)),
+            networks=NetworkConfig(tor=TorConfig(enabled=True)),
             concurrency=ConcurrencyConfig(max_parallel=5),
             interval=1800.0,
         )
@@ -321,7 +321,7 @@ class TestSynchronizerInit:
     def test_init_with_custom_config(self, mock_synchronizer_brotr: Brotr) -> None:
         """Test initialization with custom config (Tor enabled)."""
         config = SynchronizerConfig(
-            networks=NetworkConfig(tor=NetworkTypeConfig(enabled=True)),
+            networks=NetworkConfig(tor=TorConfig(enabled=True)),
             concurrency=ConcurrencyConfig(max_parallel=5),
         )
         sync = Synchronizer(brotr=mock_synchronizer_brotr, config=config)

--- a/tests/unit/services/test_validator.py
+++ b/tests/unit/services/test_validator.py
@@ -18,7 +18,7 @@ import pytest
 
 from core.brotr import Brotr, BrotrConfig
 from services.validator import Validator, ValidatorConfig
-from utils.network import NetworkConfig, NetworkTypeConfig
+from utils.network import ClearnetConfig, NetworkConfig, TorConfig
 
 
 # ============================================================================
@@ -254,7 +254,7 @@ class TestNetworkAwareValidation:
         )
 
         config = ValidatorConfig(
-            networks=NetworkConfig(clearnet=NetworkTypeConfig(timeout=5.0, max_tasks=10))
+            networks=NetworkConfig(clearnet=ClearnetConfig(timeout=5.0, max_tasks=10))
         )
         validator = Validator(brotr=mock_brotr, config=config)
 
@@ -273,9 +273,7 @@ class TestNetworkAwareValidation:
             side_effect=[[make_candidate_row("ws://onion.onion", network="tor")], []]
         )
 
-        config = ValidatorConfig(
-            networks=NetworkConfig(tor=NetworkTypeConfig(timeout=45.0, max_tasks=5))
-        )
+        config = ValidatorConfig(networks=NetworkConfig(tor=TorConfig(timeout=45.0, max_tasks=5)))
         validator = Validator(brotr=mock_brotr, config=config)
 
         with patch(
@@ -294,7 +292,7 @@ class TestNetworkAwareValidation:
         )
 
         config = ValidatorConfig(
-            networks=NetworkConfig(tor=NetworkTypeConfig(proxy_url="socks5://tor:9050"))
+            networks=NetworkConfig(tor=TorConfig(enabled=True, proxy_url="socks5://tor:9050"))
         )
         validator = Validator(brotr=mock_brotr, config=config)
 


### PR DESCRIPTION
## Summary
- Split `NetworkTypeConfig` into independent `ClearnetConfig`, `TorConfig`, `I2pConfig`, and `LokiConfig` classes
- Each class has its own defaults, fixing partial YAML override inheritance (e.g., `tor: {enabled: true}` now correctly inherits `proxy_url: socks5://tor:9050`)
- Replaced hardcoded network list in `get_enabled_networks()` with `model_fields` iteration

## Test plan
- [x] All 760 unit tests pass
- [x] Pre-commit hooks pass (ruff, mypy)
- [x] Verified partial YAML override behavior works correctly

Closes #89