### PR TITLE
fix: skip codecov upload on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@
 #                └──> build (matrix: bigbrotr/lilbrotr, main/develop only)
 #
 #   ci-success (gate for branch protection)
-#     └──> needs: [pre-commit, unit-test, integration-test]
+#     └──> needs: [pre-commit, unit-test, integration-test, build]
 #
 # ============================================================================
 
@@ -127,7 +127,7 @@ jobs:
           DB_PASSWORD: test_password
 
       - name: Upload coverage
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.11' && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@0561704f0f02c16a585d4c7555e57fa2e44cf909 # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- Skip Codecov upload step when `github.actor == 'dependabot[bot]'`
- Dependabot PRs don't have access to `CODECOV_TOKEN` (GitHub security policy), causing `fail_ci_if_error: true` to fail the entire `unit-test` job
- This unblocks all current (#158, #159, #160) and future Dependabot PRs
- Fix header comment to reflect `ci-success` includes `build`

## Why not alternatives?

| Approach | Problem |
|----------|---------|
| `fail_ci_if_error: false` | Hides real upload failures on human PRs |
| `continue-on-error: true` | Same — too broad |
| `if: github.event_name != 'pull_request'` | Skips coverage on ALL PRs |
| **`github.actor != 'dependabot[bot]'`** | Precisely targets only Dependabot |

## Test plan

- [x] CI passes on this PR (human PR, codecov token available)
- [x] After merge, rebase Dependabot PRs and verify CI passes