### PR TITLE
fix: config-driven timeouts, graceful shutdown waits, per-network semaphores

### DIFF
--- a/deployments/_template/config/services/synchronizer.yaml
+++ b/deployments/_template/config/services/synchronizer.yaml
@@ -212,12 +212,6 @@ sync_timeouts:
 # Class: src/services/synchronizer.py::SyncConcurrencyConfig
 
 concurrency:
-  # Maximum parallel relay connections (bounded by asyncio.Semaphore)
-  # Higher values = faster sync, more memory/network usage
-  # Range: 1-100
-  # Default: 10
-  max_parallel: 10
-
   # Random delay range [min, max] seconds before starting each relay
   # Prevents thundering herd on startup
   # Default: [0, 60]
@@ -271,12 +265,12 @@ overrides: []
 #
 # MINIMAL RESOURCES (low throughput, low resource usage):
 #   interval: 1800.0
-#   concurrency.max_parallel: 5
+#   networks.clearnet.max_tasks: 3
 #   filter.limit: 200
 #
 # AGGRESSIVE SYNC (high throughput, high resource usage):
 #   interval: 300.0
-#   concurrency.max_parallel: 50
+#   networks.clearnet.max_tasks: 30
 #   filter.limit: 1000
 #
 # DISABLE OVERLAY NETWORKS:

--- a/deployments/bigbrotr/config/services/synchronizer.yaml
+++ b/deployments/bigbrotr/config/services/synchronizer.yaml
@@ -24,9 +24,6 @@ networks:
   loki:
     max_tasks: 3                   # Lower concurrency for Lokinet limitations
 
-concurrency:
-  max_parallel: 20                 # Concurrent relay connections
-
 overrides:
   - url: "wss://relay.damus.io"
     timeouts:

--- a/deployments/lilbrotr/config/services/synchronizer.yaml
+++ b/deployments/lilbrotr/config/services/synchronizer.yaml
@@ -24,5 +24,4 @@ networks:
     max_tasks: 2                   # Reduced concurrency (default: 5)
 
 concurrency:
-  max_parallel: 5                  # Reduced connections (default: 10)
   stagger_delay: [0, 30]           # Shorter delay range (default: [0, 60])

--- a/src/bigbrotr/core/brotr.py
+++ b/src/bigbrotr/core/brotr.py
@@ -387,78 +387,66 @@ class Brotr:
         self,
         query: str,
         *args: Any,
-        timeout: float | None = None,  # noqa: ASYNC109
     ) -> list[asyncpg.Record]:
         """Execute a query and return all rows.
 
         Delegates to [Pool.fetch()][bigbrotr.core.pool.Pool.fetch] with
-        automatic timeout defaulting.
+        timeout from
+        [config.timeouts.query][bigbrotr.core.brotr.BrotrTimeoutsConfig].
 
         Args:
             query: SQL query with ``$1``, ``$2``, ... placeholders.
             *args: Query parameters.
-            timeout: Query timeout in seconds. Defaults to
-                [config.timeouts.query][bigbrotr.core.brotr.BrotrTimeoutsConfig].
         """
-        t = timeout if timeout is not None else self._config.timeouts.query
-        return await self._pool.fetch(query, *args, timeout=t)
+        return await self._pool.fetch(query, *args, timeout=self._config.timeouts.query)
 
     async def fetchrow(
         self,
         query: str,
         *args: Any,
-        timeout: float | None = None,  # noqa: ASYNC109
     ) -> asyncpg.Record | None:
         """Execute a query and return the first row.
 
         Delegates to [Pool.fetchrow()][bigbrotr.core.pool.Pool.fetchrow] with
-        automatic timeout defaulting.
+        timeout from
+        [config.timeouts.query][bigbrotr.core.brotr.BrotrTimeoutsConfig].
 
         Args:
             query: SQL query with ``$1``, ``$2``, ... placeholders.
             *args: Query parameters.
-            timeout: Query timeout in seconds. Defaults to
-                [config.timeouts.query][bigbrotr.core.brotr.BrotrTimeoutsConfig].
         """
-        t = timeout if timeout is not None else self._config.timeouts.query
-        return await self._pool.fetchrow(query, *args, timeout=t)
+        return await self._pool.fetchrow(query, *args, timeout=self._config.timeouts.query)
 
-    async def fetchval(self, query: str, *args: Any, timeout: float | None = None) -> Any:  # noqa: ASYNC109
+    async def fetchval(self, query: str, *args: Any) -> Any:
         """Execute a query and return the first column of the first row.
 
         Delegates to [Pool.fetchval()][bigbrotr.core.pool.Pool.fetchval] with
-        automatic timeout defaulting.
+        timeout from
+        [config.timeouts.query][bigbrotr.core.brotr.BrotrTimeoutsConfig].
 
         Args:
             query: SQL query with ``$1``, ``$2``, ... placeholders.
             *args: Query parameters.
-            timeout: Query timeout in seconds. Defaults to
-                [config.timeouts.query][bigbrotr.core.brotr.BrotrTimeoutsConfig].
         """
-        t = timeout if timeout is not None else self._config.timeouts.query
-        return await self._pool.fetchval(query, *args, timeout=t)
+        return await self._pool.fetchval(query, *args, timeout=self._config.timeouts.query)
 
-    async def execute(self, query: str, *args: Any, timeout: float | None = None) -> str:  # noqa: ASYNC109
+    async def execute(self, query: str, *args: Any) -> str:
         """Execute a query and return the command status string.
 
         Delegates to [Pool.execute()][bigbrotr.core.pool.Pool.execute] with
-        automatic timeout defaulting.
+        timeout from
+        [config.timeouts.query][bigbrotr.core.brotr.BrotrTimeoutsConfig].
 
         Args:
             query: SQL query with ``$1``, ``$2``, ... placeholders.
             *args: Query parameters.
-            timeout: Query timeout in seconds. Defaults to
-                [config.timeouts.query][bigbrotr.core.brotr.BrotrTimeoutsConfig].
         """
-        t = timeout if timeout is not None else self._config.timeouts.query
-        return await self._pool.execute(query, *args, timeout=t)
+        return await self._pool.execute(query, *args, timeout=self._config.timeouts.query)
 
     async def executemany(
         self,
         query: str,
         args_list: list[tuple[Any, ...]],
-        *,
-        timeout: float | None = None,  # noqa: ASYNC109
     ) -> None:
         """Execute a query repeatedly with different parameter sets.
 
@@ -469,11 +457,8 @@ class Brotr:
         Args:
             query: SQL query with ``$1``, ``$2``, ... placeholders.
             args_list: List of parameter tuples, one per execution.
-            timeout: Query timeout in seconds. Defaults to
-                [config.timeouts.query][bigbrotr.core.brotr.BrotrTimeoutsConfig].
         """
-        t = timeout if timeout is not None else self._config.timeouts.query
-        await self._pool.executemany(query, args_list, timeout=t)
+        await self._pool.executemany(query, args_list, timeout=self._config.timeouts.query)
 
     def transaction(self) -> AbstractAsyncContextManager[asyncpg.Connection[asyncpg.Record]]:
         """Return a transaction context manager from the pool.

--- a/src/bigbrotr/services/finder.py
+++ b/src/bigbrotr/services/finder.py
@@ -49,7 +49,6 @@ Examples:
 
 from __future__ import annotations
 
-import asyncio
 import json
 import time
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -497,8 +496,12 @@ class Finder(BaseService[FinderConfig]):
                     self._logger.debug("api_fetched", url=source.url, count=len(source_relays))
 
                     # Rate-limit between API requests (skip delay after the last source)
-                    if self._config.api.delay_between_requests > 0 and i < len(enabled_sources) - 1:
-                        await asyncio.sleep(self._config.api.delay_between_requests)
+                    if (
+                        self._config.api.delay_between_requests > 0
+                        and i < len(enabled_sources) - 1
+                        and await self.wait(self._config.api.delay_between_requests)
+                    ):
+                        break
 
                 except (TimeoutError, OSError, aiohttp.ClientError) as e:
                     self._logger.warning(

--- a/src/bigbrotr/services/monitor.py
+++ b/src/bigbrotr/services/monitor.py
@@ -700,7 +700,6 @@ class Monitor(
             self.SERVICE_NAME,
             threshold,
             networks,
-            timeout=self._brotr.config.timeouts.query,
         )
 
     # -------------------------------------------------------------------------
@@ -772,7 +771,6 @@ class Monitor(
             threshold,
             networks,
             limit,
-            timeout=self._brotr.config.timeouts.query,
         )
 
         relays: list[Relay] = []
@@ -895,7 +893,8 @@ class Monitor(
             if attempt < max_retries:
                 delay = min(retry_config.initial_delay * (2**attempt), retry_config.max_delay)
                 jitter = random.uniform(0, retry_config.jitter)  # noqa: S311
-                await asyncio.sleep(delay + jitter)
+                if await self.wait(delay + jitter):
+                    return result
                 self._logger.debug(
                     f"{operation}_retry",
                     relay=relay_url,

--- a/src/bigbrotr/services/seeder.py
+++ b/src/bigbrotr/services/seeder.py
@@ -208,9 +208,7 @@ class Seeder(BaseService[SeederConfig]):
         """
         all_urls = [relay.url for relay in relays]
 
-        new_url_list = await filter_new_relay_urls(
-            self._brotr, all_urls, timeout=self._brotr.config.timeouts.query
-        )
+        new_url_list = await filter_new_relay_urls(self._brotr, all_urls)
         new_urls = set(new_url_list)
 
         skipped_count = len(relays) - len(new_urls)

--- a/src/bigbrotr/services/validator.py
+++ b/src/bigbrotr/services/validator.py
@@ -291,9 +291,7 @@ class Validator(BatchProgressMixin, NetworkSemaphoreMixin, BaseService[Validator
             [delete_stale_candidates][bigbrotr.services.common.queries.delete_stale_candidates]:
                 The SQL query executed by this method.
         """
-        result = await delete_stale_candidates(
-            self._brotr, timeout=self._brotr.config.timeouts.query
-        )
+        result = await delete_stale_candidates(self._brotr)
         count = self._parse_delete_result(result)
         if count > 0:
             self.inc_counter("total_stale_removed", count)
@@ -315,7 +313,6 @@ class Validator(BatchProgressMixin, NetworkSemaphoreMixin, BaseService[Validator
         result = await delete_exhausted_candidates(
             self._brotr,
             self._config.cleanup.max_failures,
-            timeout=self._brotr.config.timeouts.query,
         )
         count = self._parse_delete_result(result)
         if count > 0:
@@ -359,9 +356,7 @@ class Validator(BatchProgressMixin, NetworkSemaphoreMixin, BaseService[Validator
         Returns:
             Total count of matching candidates, or 0 if none exist.
         """
-        return await count_candidates(
-            self._brotr, networks, timeout=self._brotr.config.timeouts.query
-        )
+        return await count_candidates(self._brotr, networks)
 
     # -------------------------------------------------------------------------
     # Processing
@@ -433,7 +428,6 @@ class Validator(BatchProgressMixin, NetworkSemaphoreMixin, BaseService[Validator
             networks,
             int(self._progress.started_at),
             limit,
-            timeout=self._brotr.config.timeouts.query,
         )
 
         candidates = []

--- a/tests/unit/core/test_brotr.py
+++ b/tests/unit/core/test_brotr.py
@@ -748,7 +748,7 @@ class TestBrotrQueryOperations:
 
     @pytest.mark.asyncio
     async def test_fetch_delegates_to_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test that fetch() delegates to pool.fetch() with default timeout."""
+        """Test that fetch() delegates to pool.fetch() with config timeout."""
         monkeypatch.setenv("DB_PASSWORD", "test_pass")
         brotr = Brotr()
 
@@ -758,16 +758,14 @@ class TestBrotrQueryOperations:
             assert result == []
 
     @pytest.mark.asyncio
-    async def test_fetch_passes_args_and_custom_timeout(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Test that fetch() passes query args and custom timeout."""
+    async def test_fetch_passes_args(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that fetch() passes query args with config timeout."""
         monkeypatch.setenv("DB_PASSWORD", "test_pass")
         brotr = Brotr()
 
         with patch.object(brotr._pool, "fetch", new_callable=AsyncMock, return_value=[]) as mock:
-            await brotr.fetch("SELECT $1", "arg1", timeout=5.0)
-            mock.assert_called_once_with("SELECT $1", "arg1", timeout=5.0)
+            await brotr.fetch("SELECT $1", "arg1")
+            mock.assert_called_once_with("SELECT $1", "arg1", timeout=brotr._config.timeouts.query)
 
     @pytest.mark.asyncio
     async def test_fetchrow_delegates_to_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -809,22 +807,6 @@ class TestBrotrQueryOperations:
                 timeout=brotr._config.timeouts.query,
             )
             assert result == "DELETE 5"
-
-    @pytest.mark.asyncio
-    async def test_execute_with_custom_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test that execute() passes custom timeout to pool."""
-        monkeypatch.setenv("DB_PASSWORD", "test_pass")
-        brotr = Brotr()
-
-        with patch.object(
-            brotr._pool, "execute", new_callable=AsyncMock, return_value="INSERT 0 1"
-        ) as mock:
-            await brotr.execute("INSERT INTO relay VALUES ($1)", "wss://x", timeout=10.0)
-            mock.assert_called_once_with(
-                "INSERT INTO relay VALUES ($1)",
-                "wss://x",
-                timeout=10.0,
-            )
 
 
 # ============================================================================

--- a/tests/unit/services/common/test_queries.py
+++ b/tests/unit/services/common/test_queries.py
@@ -197,7 +197,7 @@ class TestFilterNewRelayUrls:
         """Passes urls, ServiceName.VALIDATOR, and ServiceStateType.CANDIDATE."""
         urls = ["wss://new1.example.com", "wss://new2.example.com"]
 
-        await filter_new_relay_urls(mock_brotr, urls, timeout=10.0)
+        await filter_new_relay_urls(mock_brotr, urls)
 
         mock_brotr.fetch.assert_awaited_once()
         args = mock_brotr.fetch.call_args
@@ -209,7 +209,6 @@ class TestFilterNewRelayUrls:
         assert args[0][1] == urls
         assert args[0][2] == ServiceName.VALIDATOR
         assert args[0][3] == ServiceStateType.CANDIDATE
-        assert args[1]["timeout"] == 10.0
 
     @pytest.mark.asyncio
     async def test_returns_filtered_urls(self, mock_brotr: MagicMock) -> None:
@@ -250,7 +249,6 @@ class TestCountRelaysDueForCheck:
             service_name="monitor",
             threshold=1700000000,
             networks=["clearnet", "tor"],
-            timeout=5.0,
         )
 
         mock_brotr.fetchrow.assert_awaited_once()
@@ -265,7 +263,6 @@ class TestCountRelaysDueForCheck:
         assert args[0][2] == ServiceStateType.CHECKPOINT
         assert args[0][3] == ["clearnet", "tor"]
         assert args[0][4] == 1700000000
-        assert args[1]["timeout"] == 5.0
         assert result == 42
 
     @pytest.mark.asyncio
@@ -295,7 +292,6 @@ class TestFetchRelaysDueForCheck:
             threshold=1700000000,
             networks=["clearnet"],
             limit=100,
-            timeout=10.0,
         )
 
         mock_brotr.fetch.assert_awaited_once()
@@ -310,7 +306,6 @@ class TestFetchRelaysDueForCheck:
         assert args[0][3] == ["clearnet"]
         assert args[0][4] == 1700000000
         assert args[0][5] == 100
-        assert args[1]["timeout"] == 10.0
 
     @pytest.mark.asyncio
     async def test_returns_list_of_dicts(self, mock_brotr: MagicMock) -> None:
@@ -466,7 +461,7 @@ class TestCountCandidates:
         """Passes ServiceName.VALIDATOR, ServiceStateType.CANDIDATE, and networks."""
         mock_brotr.fetchrow = AsyncMock(return_value={"count": 15})
 
-        result = await count_candidates(mock_brotr, networks=["clearnet", "tor"], timeout=5.0)
+        result = await count_candidates(mock_brotr, networks=["clearnet", "tor"])
 
         mock_brotr.fetchrow.assert_awaited_once()
         args = mock_brotr.fetchrow.call_args
@@ -478,7 +473,6 @@ class TestCountCandidates:
         assert args[0][1] == ServiceName.VALIDATOR
         assert args[0][2] == ServiceStateType.CANDIDATE
         assert args[0][3] == ["clearnet", "tor"]
-        assert args[1]["timeout"] == 5.0
         assert result == 15
 
     @pytest.mark.asyncio
@@ -507,7 +501,6 @@ class TestFetchCandidateChunk:
             networks=["clearnet"],
             before_timestamp=1700000000,
             limit=50,
-            timeout=10.0,
         )
 
         mock_brotr.fetch.assert_awaited_once()
@@ -525,7 +518,6 @@ class TestFetchCandidateChunk:
         assert args[0][3] == ["clearnet"]
         assert args[0][4] == 1700000000
         assert args[0][5] == 50
-        assert args[1]["timeout"] == 10.0
 
     @pytest.mark.asyncio
     async def test_returns_list_of_dicts(self, mock_brotr: MagicMock) -> None:
@@ -564,7 +556,7 @@ class TestDeleteStaleCandidates:
         """Calls execute with ServiceName.VALIDATOR and ServiceStateType.CANDIDATE."""
         mock_brotr.execute = AsyncMock(return_value="DELETE 5")
 
-        result = await delete_stale_candidates(mock_brotr, timeout=10.0)
+        result = await delete_stale_candidates(mock_brotr)
 
         mock_brotr.execute.assert_awaited_once()
         args = mock_brotr.execute.call_args
@@ -575,7 +567,6 @@ class TestDeleteStaleCandidates:
         assert "EXISTS (SELECT 1 FROM relay r WHERE r.url = state_key)" in sql
         assert args[0][1] == ServiceName.VALIDATOR
         assert args[0][2] == ServiceStateType.CANDIDATE
-        assert args[1]["timeout"] == 10.0
         assert result == "DELETE 5"
 
     @pytest.mark.asyncio
@@ -601,7 +592,7 @@ class TestDeleteExhaustedCandidates:
         """Passes ServiceName.VALIDATOR, ServiceStateType.CANDIDATE, and max_failures."""
         mock_brotr.execute = AsyncMock(return_value="DELETE 3")
 
-        result = await delete_exhausted_candidates(mock_brotr, max_failures=5, timeout=10.0)
+        result = await delete_exhausted_candidates(mock_brotr, max_failures=5)
 
         mock_brotr.execute.assert_awaited_once()
         args = mock_brotr.execute.call_args
@@ -614,7 +605,6 @@ class TestDeleteExhaustedCandidates:
         assert args[0][1] == ServiceName.VALIDATOR
         assert args[0][2] == ServiceStateType.CANDIDATE
         assert args[0][3] == 5
-        assert args[1]["timeout"] == 10.0
         assert result == "DELETE 3"
 
     @pytest.mark.asyncio

--- a/tests/unit/services/test_synchronizer_coverage.py
+++ b/tests/unit/services/test_synchronizer_coverage.py
@@ -760,6 +760,7 @@ class TestSyncAllRelaysCoverage:
     ) -> None:
         """Test successful sync increments synced_relays and synced_events."""
         sync = Synchronizer(brotr=mock_synchronizer_brotr)
+        sync._init_semaphores(sync._config.networks)
         sync._fetch_all_cursors = AsyncMock(return_value={})  # type: ignore[method-assign]
 
         relay = Relay("wss://success.relay.com")
@@ -781,6 +782,7 @@ class TestSyncAllRelaysCoverage:
     ) -> None:
         """Test TimeoutError from wait_for increments failed_relays."""
         sync = Synchronizer(brotr=mock_synchronizer_brotr)
+        sync._init_semaphores(sync._config.networks)
         sync._fetch_all_cursors = AsyncMock(return_value={})  # type: ignore[method-assign]
 
         relay = Relay("wss://slow.relay.com")
@@ -800,6 +802,7 @@ class TestSyncAllRelaysCoverage:
     ) -> None:
         """Test asyncpg.PostgresError increments failed_relays."""
         sync = Synchronizer(brotr=mock_synchronizer_brotr)
+        sync._init_semaphores(sync._config.networks)
         sync._fetch_all_cursors = AsyncMock(return_value={})  # type: ignore[method-assign]
 
         relay = Relay("wss://db-error.relay.com")
@@ -818,6 +821,7 @@ class TestSyncAllRelaysCoverage:
     ) -> None:
         """Test OSError increments failed_relays."""
         sync = Synchronizer(brotr=mock_synchronizer_brotr)
+        sync._init_semaphores(sync._config.networks)
         sync._fetch_all_cursors = AsyncMock(return_value={})  # type: ignore[method-assign]
 
         relay = Relay("wss://net-error.relay.com")
@@ -839,6 +843,7 @@ class TestSyncAllRelaysCoverage:
             concurrency=SyncConcurrencyConfig(cursor_flush_interval=50),
         )
         sync = Synchronizer(brotr=mock_synchronizer_brotr, config=config)
+        sync._init_semaphores(sync._config.networks)
         sync._fetch_all_cursors = AsyncMock(return_value={})  # type: ignore[method-assign]
 
         relay = Relay("wss://relay.example.com")
@@ -860,10 +865,10 @@ class TestSyncAllRelaysCoverage:
         config = SynchronizerConfig(
             concurrency=SyncConcurrencyConfig(
                 cursor_flush_interval=1,  # Flush after every relay
-                max_parallel=10,
             ),
         )
         sync = Synchronizer(brotr=mock_synchronizer_brotr, config=config)
+        sync._init_semaphores(sync._config.networks)
         sync._fetch_all_cursors = AsyncMock(return_value={})  # type: ignore[method-assign]
 
         relays = [
@@ -889,6 +894,7 @@ class TestSyncAllRelaysCoverage:
             concurrency=SyncConcurrencyConfig(cursor_flush_interval=999),
         )
         sync = Synchronizer(brotr=mock_synchronizer_brotr, config=config)
+        sync._init_semaphores(sync._config.networks)
         sync._fetch_all_cursors = AsyncMock(return_value={})  # type: ignore[method-assign]
 
         relay = Relay("wss://relay.example.com")
@@ -918,6 +924,7 @@ class TestSyncAllRelaysCoverage:
             ),
         )
         sync = Synchronizer(brotr=mock_synchronizer_brotr, config=config)
+        sync._init_semaphores(sync._config.networks)
         sync._fetch_all_cursors = AsyncMock(return_value={})  # type: ignore[method-assign]
 
         relay = Relay("wss://relay.example.com")
@@ -945,6 +952,7 @@ class TestSyncAllRelaysCoverage:
             ],
         )
         sync = Synchronizer(brotr=mock_synchronizer_brotr, config=config)
+        sync._init_semaphores(sync._config.networks)
         sync._fetch_all_cursors = AsyncMock(return_value={})  # type: ignore[method-assign]
 
         relay = Relay("wss://relay.example.com")
@@ -961,6 +969,7 @@ class TestSyncAllRelaysCoverage:
     async def test_sync_all_relays_with_cached_cursor(self, mock_synchronizer_brotr: Brotr) -> None:
         """Test relay uses cached cursor for start time."""
         sync = Synchronizer(brotr=mock_synchronizer_brotr)
+        sync._init_semaphores(sync._config.networks)
         sync._fetch_all_cursors = AsyncMock(  # type: ignore[method-assign]
             return_value={"wss://relay.example.com": 100}
         )
@@ -979,6 +988,7 @@ class TestSyncAllRelaysCoverage:
     async def test_sync_all_relays_exception_group(self, mock_synchronizer_brotr: Brotr) -> None:
         """Test ExceptionGroup from TaskGroup is handled (lines 659-666)."""
         sync = Synchronizer(brotr=mock_synchronizer_brotr)
+        sync._init_semaphores(sync._config.networks)
         sync._fetch_all_cursors = AsyncMock(return_value={})  # type: ignore[method-assign]
 
         relay = Relay("wss://exploding.relay.com")


### PR DESCRIPTION
## Summary

- **Config-driven timeouts**: removed `timeout` parameter from all Brotr public methods (`fetch`, `fetchrow`, `fetchval`, `execute`, `executemany`) and all 13 query functions in `queries.py`. Timeouts are now purely driven by `BrotrTimeoutsConfig` (`timeouts.query` for reads, `timeouts.batch` for writes in transactions).
- **Graceful shutdown**: replaced `asyncio.sleep()` with `self.wait()` in Finder and Monitor, enabling immediate response to shutdown signals instead of blocking until sleep completes.
- **Per-network semaphores**: refactored Synchronizer to use `NetworkSemaphoreMixin` with per-network concurrency limits (from `networks.<type>.max_tasks`), replacing the flat `max_parallel` semaphore. Removed deprecated `max_parallel` field from `SyncConcurrencyConfig` and all deployment YAMLs.

## Changes

| Area | Files | Description |
|------|-------|-------------|
| Core | `brotr.py` | Timeout removed from 5 public methods, all use config internally |
| Queries | `queries.py` | Timeout param removed from all functions; `promote_candidates()` uses `config.timeouts.batch` explicitly for raw transaction |
| Services | `finder.py`, `monitor.py` | `asyncio.sleep()` → `self.wait()` for graceful shutdown |
| Services | `synchronizer.py` | `NetworkSemaphoreMixin`, removed `max_parallel` |
| Services | `seeder.py`, `validator.py` | Removed `timeout=` from query call sites |
| Config | 3 deployment YAMLs | Removed `max_parallel` field |
| Tests | 4 test files | Updated for timeout removal, semaphore refactoring |

## Test plan

- [x] `make ci` passes (ruff + mypy + 2060 tests)
- [ ] Verify Monitor graceful shutdown with `--once` flag
- [ ] Verify Synchronizer per-network concurrency with mixed clearnet/tor relays