### PR TITLE
fix: use CHECKPOINT state type for publisher timestamps

### DIFF
--- a/src/bigbrotr/services/monitor_publisher.py
+++ b/src/bigbrotr/services/monitor_publisher.py
@@ -150,7 +150,7 @@ class MonitorPublisherMixin:
 
         results = await self._brotr.get_service_state(  # type: ignore[attr-defined]
             self.SERVICE_NAME,  # type: ignore[attr-defined]
-            ServiceStateType.CURSOR,
+            ServiceStateType.CHECKPOINT,
             "last_announcement",
         )
         state = results[0].state_value if results else {}
@@ -168,7 +168,7 @@ class MonitorPublisherMixin:
                 [
                     ServiceState(
                         service_name=self.SERVICE_NAME,  # type: ignore[attr-defined]
-                        state_type=ServiceStateType.CURSOR,
+                        state_type=ServiceStateType.CHECKPOINT,
                         state_key="last_announcement",
                         state_value={"timestamp": now},
                         updated_at=int(now),
@@ -193,7 +193,7 @@ class MonitorPublisherMixin:
 
         results = await self._brotr.get_service_state(  # type: ignore[attr-defined]
             self.SERVICE_NAME,  # type: ignore[attr-defined]
-            ServiceStateType.CURSOR,
+            ServiceStateType.CHECKPOINT,
             "last_profile",
         )
         last_profile = results[0].state_value.get("timestamp", 0.0) if results else 0.0
@@ -210,7 +210,7 @@ class MonitorPublisherMixin:
                 [
                     ServiceState(
                         service_name=self.SERVICE_NAME,  # type: ignore[attr-defined]
-                        state_type=ServiceStateType.CURSOR,
+                        state_type=ServiceStateType.CHECKPOINT,
                         state_key="last_profile",
                         state_value={"timestamp": now},
                         updated_at=int(now),

--- a/tests/unit/services/test_monitor_publisher.py
+++ b/tests/unit/services/test_monitor_publisher.py
@@ -435,7 +435,7 @@ class TestPublishAnnouncement:
             return_value=[
                 ServiceState(
                     service_name=ServiceName.MONITOR,
-                    state_type=ServiceStateType.CURSOR,
+                    state_type=ServiceStateType.CHECKPOINT,
                     state_key="last_announcement",
                     state_value={"timestamp": now},
                     updated_at=int(now),
@@ -474,7 +474,7 @@ class TestPublishAnnouncement:
             return_value=[
                 ServiceState(
                     service_name=ServiceName.MONITOR,
-                    state_type=ServiceStateType.CURSOR,
+                    state_type=ServiceStateType.CHECKPOINT,
                     state_key="last_announcement",
                     state_value={"timestamp": old_timestamp},
                     updated_at=int(old_timestamp),
@@ -558,7 +558,7 @@ class TestPublishProfile:
             return_value=[
                 ServiceState(
                     service_name=ServiceName.MONITOR,
-                    state_type=ServiceStateType.CURSOR,
+                    state_type=ServiceStateType.CHECKPOINT,
                     state_key="last_profile",
                     state_value={"timestamp": now},
                     updated_at=int(now),


### PR DESCRIPTION
## Summary

- `MonitorPublisherMixin` used `ServiceStateType.CURSOR` for `last_announcement` and `last_profile` timestamps, but these are semantically checkpoints ("when was this last done"), not cursors ("position in an ordered stream").
- Changed 4 occurrences in `monitor_publisher.py` (lines 153, 171, 196, 213) from `CURSOR` to `CHECKPOINT`.
- Updated 3 test assertions in `test_monitor_publisher.py` (lines 438, 477, 561).

## Migration

No SQL migration needed. Orphaned rows with `state_type='cursor'` and keys `last_announcement`/`last_profile` are harmless — on first cycle after deploy, the service re-publishes (idempotent) and creates new rows with `state_type='checkpoint'`.

## Test plan

- [x] `make ci` passes (ruff + mypy + 2060 tests)
- [ ] Verify Monitor publishes announcement/profile on first cycle after deploy (re-creates checkpoint rows)