### PR TITLE
fix: remove system Python packages from production Docker image

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -62,6 +62,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tini \
     && rm -rf /var/lib/apt/lists/*
 
+# Remove pre-installed system Python packages (pip, setuptools, wheel and transitive deps).
+# The production image uses .venv exclusively; these are unused and trigger Trivy findings.
+RUN rm -rf /usr/local/lib/python*/dist-packages /usr/local/lib/python*/ensurepip \
+    && rm -f /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/wheel
+
 # Copy the virtual environment from builder (no pip/setuptools in production image)
 COPY --from=builder /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
## Summary

- Remove pre-installed system Python packages (`pip`, `setuptools`, `wheel`, `jaraco.context`, etc.) from the production Docker image
- The production image runs exclusively from `.venv` copied from the builder stage; system `dist-packages` is unused dead code
- Eliminates Trivy HIGH findings: `jaraco.context` (CVE-2026-23949) and `wheel` (CVE-2026-24049)

## Test plan

- [ ] `docker build` succeeds for bigbrotr deployment
- [ ] `bigbrotr --help` works in the container
- [ ] `dist-packages` directory and `pip` binary are absent from the production image
- [ ] Trivy scan passes with zero CRITICAL/HIGH findings
- [ ] CI Build job passes on GitHub Actions