### PR TITLE
fix: remove system site-packages to resolve Trivy findings

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -55,16 +55,17 @@ RUN groupadd -g 1000 ${DEPLOYMENT} && \
 
 WORKDIR /app
 
-# Install runtime dependencies (libpq for asyncpg, libsecp256k1 for crypto, tini for PID 1)
+# Install runtime dependencies then strip the base image's Python packaging toolchain.
+# The production image runs exclusively from the .venv copied from the builder stage;
+# system-level Python packages are unused and only increase the attack surface.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 \
     libsecp256k1-dev \
     tini \
-    && rm -rf /var/lib/apt/lists/*
-
-# Remove pre-installed system Python packages (pip, setuptools, wheel and transitive deps).
-# The production image uses .venv exclusively; these are unused and trigger Trivy findings.
-RUN rm -rf /usr/local/lib/python*/dist-packages /usr/local/lib/python*/ensurepip \
+    && rm -rf /var/lib/apt/lists/* \
+              /usr/local/lib/python*/site-packages \
+              /usr/local/lib/python*/dist-packages \
+              /usr/local/lib/python*/ensurepip \
     && rm -f /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/wheel
 
 # Copy the virtual environment from builder (no pip/setuptools in production image)


### PR DESCRIPTION
## Summary

- Extends the system Python cleanup in the Dockerfile to also remove `/usr/local/lib/python*/site-packages/` (not just `dist-packages`)
- Trivy found `jaraco.context` (CVE-2026-23949) and `wheel` (CVE-2026-24049) vendored inside `setuptools` at `site-packages/setuptools/_vendor/`
- The previous PR #171 only cleaned `dist-packages`; these packages live in `site-packages` in the `python:3.11.14-slim` base image

## Verification

- Local Docker build succeeds
- Container runs correctly (`bigbrotr --help`)
- No `jaraco`, `wheel`, or `setuptools` found anywhere in the production image