### PR TITLE
docs: replace stale uv pip references

### DIFF
--- a/docs/how-to/manual-deploy.md
+++ b/docs/how-to/manual-deploy.md
@@ -74,9 +74,7 @@ sudo systemctl start pgbouncer && sudo systemctl enable pgbouncer
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh  # install uv (one-time)
-uv venv /opt/bigbrotr/venv
-source /opt/bigbrotr/venv/bin/activate
-uv pip install .
+uv sync --no-dev
 ```
 
 ### Set environment variables

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -254,8 +254,7 @@ For systemd deployments, the `Restart=always` directive provides the same behavi
     === "Manual"
 
         ```bash
-        source /opt/bigbrotr/venv/bin/activate
-        uv pip install .
+        uv sync --no-dev
         sudo systemctl restart bigbrotr-finder bigbrotr-validator bigbrotr-monitor bigbrotr-synchronizer
         ```
 


### PR DESCRIPTION
## Summary

- Replace `uv pip install .` with `uv sync --no-dev` in manual deployment and troubleshooting docs
- `uv pip` is the compatibility layer; `uv sync` is the correct command with `uv.lock`