### PR TITLE
fix: resolve remaining HIGH audit issues

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -90,9 +90,5 @@ STOPSIGNAL SIGTERM
 # Use tini as PID 1 init process
 ENTRYPOINT ["tini", "--"]
 
-# Health check (Prometheus metrics endpoint)
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/metrics')" || exit 1
-
 # Default command (uses console_scripts entry point)
 CMD ["bigbrotr"]

--- a/deployments/_template/docker-compose.yaml
+++ b/deployments/_template/docker-compose.yaml
@@ -461,6 +461,46 @@ services:
         max-file: "3"
 
   # --------------------------------------------------------------------------
+  # Alertmanager (Alert Routing)
+  # --------------------------------------------------------------------------
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: myimpl-alertmanager             # <-- CUSTOMIZE
+    restart: unless-stopped
+
+    volumes:
+      - ./monitoring/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+
+    ports:
+      # CUSTOMIZE: Use unique port to avoid conflicts
+      - "127.0.0.1:9093:9093"
+
+    networks:
+      - myimpl-monitoring-network                   # <-- CUSTOMIZE
+
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--storage.path=/alertmanager"
+
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9093/-/healthy"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 128M
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
+
+  # --------------------------------------------------------------------------
   # Grafana (Metrics Visualization)
   # --------------------------------------------------------------------------
   grafana:

--- a/deployments/_template/monitoring/alertmanager/alertmanager.yml
+++ b/deployments/_template/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,32 @@
+# ============================================================================
+# Alertmanager Configuration Template
+# ============================================================================
+# Routes alerts from Prometheus to notification channels.
+# CUSTOMIZE: Configure receivers for your notification preferences.
+# ============================================================================
+
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ["alertname", "service"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: "default"
+
+  routes:
+    - match:
+        severity: critical
+      receiver: "default"
+      repeat_interval: 1h
+
+receivers:
+  - name: "default"
+    # CUSTOMIZE: Add notification integrations here.
+    # Examples:
+    #   webhook_configs:
+    #     - url: "http://your-webhook-endpoint"
+    #   slack_configs:
+    #     - api_url: "https://hooks.slack.com/services/..."
+    #       channel: "#alerts"

--- a/deployments/_template/monitoring/prometheus/prometheus.yaml
+++ b/deployments/_template/monitoring/prometheus/prometheus.yaml
@@ -9,6 +9,11 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
 scrape_configs:
   # --------------------------------------------------------------------------
   # MyImpl Services                                # <-- CUSTOMIZE

--- a/deployments/bigbrotr/docker-compose.yaml
+++ b/deployments/bigbrotr/docker-compose.yaml
@@ -530,6 +530,45 @@ services:
         max-file: "3"
 
   # --------------------------------------------------------------------------
+  # Alertmanager (Alert Routing)
+  # --------------------------------------------------------------------------
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: bigbrotr-alertmanager
+    restart: unless-stopped
+
+    volumes:
+      - ./monitoring/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+
+    ports:
+      - "127.0.0.1:9093:9093"
+
+    networks:
+      - bigbrotr-monitoring-network
+
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--storage.path=/alertmanager"
+
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9093/-/healthy"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 128M
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
+
+  # --------------------------------------------------------------------------
   # Grafana (Metrics Visualization)
   # --------------------------------------------------------------------------
   grafana:

--- a/deployments/bigbrotr/monitoring/alertmanager/alertmanager.yml
+++ b/deployments/bigbrotr/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,32 @@
+# ============================================================================
+# Alertmanager Configuration for BigBrotr
+# ============================================================================
+# Routes alerts from Prometheus to notification channels.
+# CUSTOMIZE: Configure receivers for your notification preferences.
+# ============================================================================
+
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ["alertname", "service"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: "default"
+
+  routes:
+    - match:
+        severity: critical
+      receiver: "default"
+      repeat_interval: 1h
+
+receivers:
+  - name: "default"
+    # CUSTOMIZE: Add notification integrations here.
+    # Examples:
+    #   webhook_configs:
+    #     - url: "http://your-webhook-endpoint"
+    #   slack_configs:
+    #     - api_url: "https://hooks.slack.com/services/..."
+    #       channel: "#alerts"

--- a/deployments/bigbrotr/monitoring/prometheus/prometheus.yaml
+++ b/deployments/bigbrotr/monitoring/prometheus/prometheus.yaml
@@ -11,6 +11,11 @@ global:
 rule_files:
   - /etc/prometheus/rules/*.yml
 
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
 scrape_configs:
   # --------------------------------------------------------------------------
   # BigBrotr Services

--- a/deployments/lilbrotr/docker-compose.yaml
+++ b/deployments/lilbrotr/docker-compose.yaml
@@ -531,6 +531,45 @@ services:
         max-file: "3"
 
   # --------------------------------------------------------------------------
+  # Alertmanager (Alert Routing)
+  # --------------------------------------------------------------------------
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: lilbrotr-alertmanager
+    restart: unless-stopped
+
+    volumes:
+      - ./monitoring/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+
+    ports:
+      - "127.0.0.1:9094:9093"
+
+    networks:
+      - lilbrotr-monitoring-network
+
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--storage.path=/alertmanager"
+
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9093/-/healthy"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 128M
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
+
+  # --------------------------------------------------------------------------
   # Grafana (Metrics Visualization)
   # --------------------------------------------------------------------------
   grafana:

--- a/deployments/lilbrotr/monitoring/alertmanager/alertmanager.yml
+++ b/deployments/lilbrotr/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,32 @@
+# ============================================================================
+# Alertmanager Configuration for LilBrotr
+# ============================================================================
+# Routes alerts from Prometheus to notification channels.
+# CUSTOMIZE: Configure receivers for your notification preferences.
+# ============================================================================
+
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ["alertname", "service"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: "default"
+
+  routes:
+    - match:
+        severity: critical
+      receiver: "default"
+      repeat_interval: 1h
+
+receivers:
+  - name: "default"
+    # CUSTOMIZE: Add notification integrations here.
+    # Examples:
+    #   webhook_configs:
+    #     - url: "http://your-webhook-endpoint"
+    #   slack_configs:
+    #     - api_url: "https://hooks.slack.com/services/..."
+    #       channel: "#alerts"

--- a/deployments/lilbrotr/monitoring/prometheus/prometheus.yaml
+++ b/deployments/lilbrotr/monitoring/prometheus/prometheus.yaml
@@ -11,6 +11,11 @@ global:
 rule_files:
   - /etc/prometheus/rules/*.yml
 
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
 scrape_configs:
   # --------------------------------------------------------------------------
   # LilBrotr Services

--- a/src/bigbrotr/models/constants.py
+++ b/src/bigbrotr/models/constants.py
@@ -15,10 +15,6 @@ See Also:
 from __future__ import annotations
 
 from enum import IntEnum, StrEnum
-from typing import Final
-
-
-DEFAULT_TIMEOUT: Final[float] = 10.0
 
 
 class NetworkType(StrEnum):

--- a/src/bigbrotr/nips/nip11/info.py
+++ b/src/bigbrotr/nips/nip11/info.py
@@ -40,10 +40,11 @@ from typing import Any, ClassVar, Self
 import aiohttp
 from aiohttp_socks import ProxyConnector
 
-from bigbrotr.models.constants import DEFAULT_TIMEOUT, NetworkType
+from bigbrotr.models.constants import NetworkType
 from bigbrotr.models.relay import Relay  # noqa: TC001
 from bigbrotr.nips.base import BaseNipMetadata
 from bigbrotr.utils.http import read_bounded_json
+from bigbrotr.utils.transport import DEFAULT_TIMEOUT
 
 from .data import Nip11InfoData
 from .logs import Nip11InfoLogs

--- a/src/bigbrotr/nips/nip11/nip11.py
+++ b/src/bigbrotr/nips/nip11/nip11.py
@@ -25,7 +25,6 @@ import logging
 from dataclasses import dataclass
 from typing import NamedTuple
 
-from bigbrotr.models.constants import DEFAULT_TIMEOUT
 from bigbrotr.models.metadata import Metadata, MetadataType
 from bigbrotr.models.relay import Relay  # noqa: TC001
 from bigbrotr.models.relay_metadata import RelayMetadata
@@ -35,6 +34,7 @@ from bigbrotr.nips.base import (
     BaseNipOptions,
     BaseNipSelection,
 )
+from bigbrotr.utils.transport import DEFAULT_TIMEOUT
 
 from .info import Nip11InfoMetadata
 

--- a/src/bigbrotr/nips/nip66/dns.py
+++ b/src/bigbrotr/nips/nip66/dns.py
@@ -51,9 +51,10 @@ if TYPE_CHECKING:
     from dns.rdtypes.IN.A import A
     from dns.rdtypes.IN.AAAA import AAAA
 
-from bigbrotr.models.constants import DEFAULT_TIMEOUT, NetworkType
+from bigbrotr.models.constants import NetworkType
 from bigbrotr.models.relay import Relay  # noqa: TC001
 from bigbrotr.nips.base import BaseNipMetadata
+from bigbrotr.utils.transport import DEFAULT_TIMEOUT
 
 from .data import Nip66DnsData
 from .logs import Nip66DnsLogs

--- a/src/bigbrotr/nips/nip66/http.py
+++ b/src/bigbrotr/nips/nip66/http.py
@@ -39,9 +39,10 @@ from typing import Any, Self
 import aiohttp
 from aiohttp_socks import ProxyConnector
 
-from bigbrotr.models.constants import DEFAULT_TIMEOUT, NetworkType
+from bigbrotr.models.constants import NetworkType
 from bigbrotr.models.relay import Relay  # noqa: TC001
 from bigbrotr.nips.base import BaseNipMetadata
+from bigbrotr.utils.transport import DEFAULT_TIMEOUT
 
 from .data import Nip66HttpData
 from .logs import Nip66HttpLogs

--- a/src/bigbrotr/nips/nip66/nip66.py
+++ b/src/bigbrotr/nips/nip66/nip66.py
@@ -33,7 +33,6 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from bigbrotr.models.constants import DEFAULT_TIMEOUT
 from bigbrotr.models.metadata import Metadata, MetadataType
 from bigbrotr.models.relay import Relay  # noqa: TC001
 from bigbrotr.models.relay_metadata import RelayMetadata
@@ -44,6 +43,7 @@ from bigbrotr.nips.base import (
     BaseNipOptions,
     BaseNipSelection,
 )
+from bigbrotr.utils.transport import DEFAULT_TIMEOUT
 
 from .dns import Nip66DnsMetadata
 from .geo import Nip66GeoMetadata

--- a/src/bigbrotr/nips/nip66/rtt.py
+++ b/src/bigbrotr/nips/nip66/rtt.py
@@ -44,9 +44,10 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Self
 
 from nostr_sdk import Filter, NostrSdkError, RelayUrl
 
-from bigbrotr.models.constants import DEFAULT_TIMEOUT, NetworkType
+from bigbrotr.models.constants import NetworkType
 from bigbrotr.models.relay import Relay  # noqa: TC001
 from bigbrotr.nips.base import BaseNipMetadata
+from bigbrotr.utils.transport import DEFAULT_TIMEOUT
 
 from .data import Nip66RttData
 from .logs import Nip66RttMultiPhaseLogs

--- a/src/bigbrotr/nips/nip66/ssl.py
+++ b/src/bigbrotr/nips/nip66/ssl.py
@@ -43,9 +43,10 @@ from typing import Any, Self
 from cryptography import x509
 from cryptography.x509.oid import NameOID
 
-from bigbrotr.models.constants import DEFAULT_TIMEOUT, NetworkType
+from bigbrotr.models.constants import NetworkType
 from bigbrotr.models.relay import Relay  # noqa: TC001
 from bigbrotr.nips.base import BaseNipMetadata
+from bigbrotr.utils.transport import DEFAULT_TIMEOUT
 
 from .data import Nip66SslData
 from .logs import Nip66SslLogs

--- a/src/bigbrotr/services/monitor_publisher.py
+++ b/src/bigbrotr/services/monitor_publisher.py
@@ -112,7 +112,7 @@ class MonitorPublisherMixin:
         if not builders or not relays:
             return
 
-        client = create_client(self._keys)
+        client = await create_client(self._keys)
         for relay in relays:
             await client.add_relay(RelayUrl.parse(relay.url))
         try:

--- a/src/bigbrotr/services/synchronizer.py
+++ b/src/bigbrotr/services/synchronizer.py
@@ -580,7 +580,7 @@ async def _sync_relay_events(
     skipped_events = 0
 
     proxy_url = ctx.network_config.get_proxy_url(relay.network)
-    client = create_client(ctx.keys, proxy_url)
+    client = await create_client(ctx.keys, proxy_url)
     await client.add_relay(RelayUrl.parse(relay.url))
 
     try:

--- a/tests/unit/nips/test_base.py
+++ b/tests/unit/nips/test_base.py
@@ -3,7 +3,6 @@
 import pytest
 from pydantic import ValidationError
 
-from bigbrotr.models.constants import DEFAULT_TIMEOUT
 from bigbrotr.models.relay import Relay
 from bigbrotr.nips.base import (
     BaseData,
@@ -17,6 +16,7 @@ from bigbrotr.nips.base import (
 from bigbrotr.nips.nip11.nip11 import Nip11, Nip11Dependencies, Nip11Options, Nip11Selection
 from bigbrotr.nips.nip66.nip66 import Nip66, Nip66Dependencies, Nip66Options, Nip66Selection
 from bigbrotr.nips.parsing import FieldSpec
+from bigbrotr.utils.transport import DEFAULT_TIMEOUT
 
 
 # =============================================================================

--- a/tests/unit/services/test_monitor_publisher.py
+++ b/tests/unit/services/test_monitor_publisher.py
@@ -233,6 +233,7 @@ class TestBroadcastEvents:
 
         with patch(
             "bigbrotr.services.monitor_publisher.create_client",
+            new_callable=AsyncMock,
             return_value=mock_client,
         ):
             await publisher._broadcast_events([mock_builder], [relay])
@@ -255,6 +256,7 @@ class TestBroadcastEvents:
 
         with patch(
             "bigbrotr.services.monitor_publisher.create_client",
+            new_callable=AsyncMock,
             return_value=mock_client,
         ):
             await publisher._broadcast_events(builders, relays)
@@ -295,6 +297,7 @@ class TestBroadcastEvents:
         with (
             patch(
                 "bigbrotr.services.monitor_publisher.create_client",
+                new_callable=AsyncMock,
                 return_value=mock_client,
             ),
             pytest.raises(OSError, match="send failed"),
@@ -455,6 +458,7 @@ class TestPublishAnnouncement:
 
         with patch(
             "bigbrotr.services.monitor_publisher.create_client",
+            new_callable=AsyncMock,
             return_value=mock_client,
         ):
             await publisher._publish_announcement()
@@ -485,6 +489,7 @@ class TestPublishAnnouncement:
 
         with patch(
             "bigbrotr.services.monitor_publisher.create_client",
+            new_callable=AsyncMock,
             return_value=mock_client,
         ):
             await publisher._publish_announcement()
@@ -502,6 +507,7 @@ class TestPublishAnnouncement:
 
         with patch(
             "bigbrotr.services.monitor_publisher.create_client",
+            new_callable=AsyncMock,
             return_value=mock_client,
         ):
             await publisher._publish_announcement()
@@ -578,6 +584,7 @@ class TestPublishProfile:
 
         with patch(
             "bigbrotr.services.monitor_publisher.create_client",
+            new_callable=AsyncMock,
             return_value=mock_client,
         ):
             await publisher._publish_profile()
@@ -595,6 +602,7 @@ class TestPublishProfile:
 
         with patch(
             "bigbrotr.services.monitor_publisher.create_client",
+            new_callable=AsyncMock,
             return_value=mock_client,
         ):
             await publisher._publish_profile()
@@ -671,6 +679,7 @@ class TestPublishRelayDiscoveries:
 
         with patch(
             "bigbrotr.services.monitor_publisher.create_client",
+            new_callable=AsyncMock,
             return_value=mock_client,
         ):
             await combined_harness._publish_relay_discoveries([(relay, result)])
@@ -709,6 +718,7 @@ class TestPublishRelayDiscoveries:
 
         with patch(
             "bigbrotr.services.monitor_publisher.create_client",
+            new_callable=AsyncMock,
             return_value=mock_client,
         ):
             await combined_harness._publish_relay_discoveries(
@@ -732,6 +742,7 @@ class TestPublishRelayDiscoveries:
 
         with patch(
             "bigbrotr.services.monitor_publisher.create_client",
+            new_callable=AsyncMock,
             return_value=mock_client,
         ):
             await combined_harness._publish_relay_discoveries([(relay, result)])

--- a/tests/unit/services/test_synchronizer_coverage.py
+++ b/tests/unit/services/test_synchronizer_coverage.py
@@ -466,7 +466,11 @@ class TestSyncRelayEvents:
         mock_client.add_relay = AsyncMock()
 
         with (
-            patch("bigbrotr.services.synchronizer.create_client", return_value=mock_client),
+            patch(
+                "bigbrotr.services.synchronizer.create_client",
+                new_callable=AsyncMock,
+                return_value=mock_client,
+            ),
             patch(
                 "bigbrotr.services.synchronizer._insert_batch",
                 new_callable=AsyncMock,
@@ -496,7 +500,11 @@ class TestSyncRelayEvents:
         mock_client.shutdown = AsyncMock()
         mock_client.add_relay = AsyncMock()
 
-        with patch("bigbrotr.services.synchronizer.create_client", return_value=mock_client):
+        with patch(
+            "bigbrotr.services.synchronizer.create_client",
+            new_callable=AsyncMock,
+            return_value=mock_client,
+        ):
             synced, invalid, skipped = await _sync_relay_events(
                 relay=relay, start_time=100, end_time=1000, ctx=ctx
             )
@@ -515,7 +523,11 @@ class TestSyncRelayEvents:
         mock_client.shutdown = AsyncMock()
         mock_client.add_relay = AsyncMock()
 
-        with patch("bigbrotr.services.synchronizer.create_client", return_value=mock_client):
+        with patch(
+            "bigbrotr.services.synchronizer.create_client",
+            new_callable=AsyncMock,
+            return_value=mock_client,
+        ):
             synced, invalid, skipped = await _sync_relay_events(
                 relay=relay, start_time=100, end_time=1000, ctx=ctx
             )
@@ -534,7 +546,11 @@ class TestSyncRelayEvents:
         mock_client.shutdown = AsyncMock()
         mock_client.add_relay = AsyncMock()
 
-        with patch("bigbrotr.services.synchronizer.create_client", return_value=mock_client):
+        with patch(
+            "bigbrotr.services.synchronizer.create_client",
+            new_callable=AsyncMock,
+            return_value=mock_client,
+        ):
             synced, invalid, skipped = await _sync_relay_events(
                 relay=relay, start_time=100, end_time=1000, ctx=ctx
             )
@@ -557,7 +573,11 @@ class TestSyncRelayEvents:
         mock_client.shutdown = AsyncMock()
         mock_client.add_relay = AsyncMock()
 
-        with patch("bigbrotr.services.synchronizer.create_client", return_value=mock_client):
+        with patch(
+            "bigbrotr.services.synchronizer.create_client",
+            new_callable=AsyncMock,
+            return_value=mock_client,
+        ):
             await _sync_relay_events(relay=relay, start_time=100, end_time=1000, ctx=ctx)
 
         mock_client.disconnect.assert_called_once()
@@ -573,7 +593,11 @@ class TestSyncRelayEvents:
         mock_client.shutdown = AsyncMock()
         mock_client.add_relay = AsyncMock()
 
-        with patch("bigbrotr.services.synchronizer.create_client", return_value=mock_client):
+        with patch(
+            "bigbrotr.services.synchronizer.create_client",
+            new_callable=AsyncMock,
+            return_value=mock_client,
+        ):
             await _sync_relay_events(relay=relay, start_time=100, end_time=1000, ctx=ctx)
 
         mock_client.shutdown.assert_called_once()
@@ -602,7 +626,9 @@ class TestSyncRelayEvents:
         mock_client.add_relay = AsyncMock()
 
         with patch(
-            "bigbrotr.services.synchronizer.create_client", return_value=mock_client
+            "bigbrotr.services.synchronizer.create_client",
+            new_callable=AsyncMock,
+            return_value=mock_client,
         ) as mock_create:
             await _sync_relay_events(relay=relay, start_time=100, end_time=1000, ctx=ctx)
 
@@ -636,7 +662,11 @@ class TestSyncRelayEvents:
                 super().__init__(since, until, limit=1)
 
         with (
-            patch("bigbrotr.services.synchronizer.create_client", return_value=mock_client),
+            patch(
+                "bigbrotr.services.synchronizer.create_client",
+                new_callable=AsyncMock,
+                return_value=mock_client,
+            ),
             patch("bigbrotr.services.synchronizer.EventBatch", LimitedBatch),
             patch(
                 "bigbrotr.services.synchronizer._insert_batch",


### PR DESCRIPTION
## Summary
- Make `create_client()` async to avoid blocking DNS resolution in the event loop; proxy hostname resolution now uses `asyncio.to_thread`
- Remove Dockerfile `HEALTHCHECK` directive (orchestrator responsibility)
- Move `DEFAULT_TIMEOUT` constant from `models.constants` to `utils.transport` to respect the DAG constraint (models must not define I/O defaults)
- Add Alertmanager service to all 3 deployments with Prometheus alerting integration and configurable notification receivers

## Test plan
- [x] `ruff check src/ tests/` — 0 errors
- [x] `mypy src/bigbrotr` — 0 errors
- [x] `pytest tests/ --ignore=tests/integration/` — 2187 passed
- [x] All pre-commit hooks passed (ruff-format, yamllint, hadolint, detect-secrets, codespell)