### PR TITLE
refactor: simplify Brotr methods, align ServiceState db_params, clean up candidate lifecycle

### DIFF
--- a/docs/user-guide/architecture.md
+++ b/docs/user-guide/architecture.md
@@ -458,7 +458,7 @@ Configuration classes inherit from `BaseServiceConfig` which provides:
 | `count_relays_due_for_check(brotr, ...)` | Count relays needing health check |
 | `fetch_relays_due_for_check(brotr, ...)` | Fetch relays needing health check |
 | `get_events_with_relay_urls(brotr, ...)` | Events containing relay URLs |
-| `upsert_candidates(brotr, relays)` | Insert/update validation candidates |
+| `insert_candidates(brotr, relays)` | Insert new validation candidates (filters duplicates) |
 | `count_candidates(brotr, networks)` | Count pending candidates |
 | `fetch_candidate_chunk(brotr, ...)` | Fetch candidate batch for validation |
 | `delete_stale_candidates(brotr)` | Remove candidates already in relay table |

--- a/docs/user-guide/pipeline.md
+++ b/docs/user-guide/pipeline.md
@@ -81,7 +81,7 @@ flowchart TD
 
 1. Read the seed file (one URL per line, `#` comments skipped)
 2. Parse each URL into a `Relay` object (validates URL format, detects network type)
-3. Insert as candidates via `upsert_candidates()` (default) or directly to the `relay` table
+3. Insert as candidates via `insert_candidates()` (default) or directly to the `relay` table
 
 !!! tip
     Set `to_validate: false` in the Seeder config to skip validation and insert relays directly. This is useful when seeding with a trusted, pre-validated relay list.
@@ -127,11 +127,10 @@ flowchart TD
     G --> I
     H --> I
 
-    I --> J["filter_new_relay_urls()"]
-    J --> K["upsert_candidates()"]
+    I --> J["insert_candidates()"]
 
     style A fill:#7B1FA2,color:#fff,stroke:#4A148C
-    style K fill:#311B92,color:#fff,stroke:#1A237E
+    style J fill:#311B92,color:#fff,stroke:#1A237E
 ```
 
 **Discovery sources:**

--- a/src/bigbrotr/services/common/__init__.py
+++ b/src/bigbrotr/services/common/__init__.py
@@ -45,8 +45,8 @@ from .queries import (
     get_all_relays,
     get_all_service_cursors,
     get_events_with_relay_urls,
+    insert_candidates,
     promote_candidates,
-    upsert_candidates,
 )
 
 
@@ -71,6 +71,6 @@ __all__ = [
     "get_all_relays",
     "get_all_service_cursors",
     "get_events_with_relay_urls",
+    "insert_candidates",
     "promote_candidates",
-    "upsert_candidates",
 ]

--- a/src/bigbrotr/services/finder.py
+++ b/src/bigbrotr/services/finder.py
@@ -11,7 +11,7 @@ Discovers Nostr relay URLs from two sources:
 
 Discovered URLs are inserted as validation candidates for the
 [Validator][bigbrotr.services.validator.Validator] service via
-[upsert_candidates][bigbrotr.services.common.queries.upsert_candidates].
+[insert_candidates][bigbrotr.services.common.queries.insert_candidates].
 
 Note:
     Event scanning uses per-relay cursor-based pagination so that
@@ -64,7 +64,7 @@ from bigbrotr.models.constants import EventKind, ServiceName
 from bigbrotr.models.service_state import ServiceState, ServiceStateType
 from bigbrotr.utils.http import read_bounded_json
 
-from .common.queries import get_all_relay_urls, get_events_with_relay_urls, upsert_candidates
+from .common.queries import get_all_relay_urls, get_events_with_relay_urls, insert_candidates
 
 
 if TYPE_CHECKING:
@@ -187,7 +187,7 @@ class Finder(BaseService[FinderConfig]):
     Discovers Nostr relay URLs from external APIs and stored database events,
     then inserts them as validation candidates for the
     [Validator][bigbrotr.services.validator.Validator] service via
-    [upsert_candidates][bigbrotr.services.common.queries.upsert_candidates].
+    [insert_candidates][bigbrotr.services.common.queries.insert_candidates].
 
     See Also:
         [FinderConfig][bigbrotr.services.finder.FinderConfig]: Configuration
@@ -415,7 +415,7 @@ class Finder(BaseService[FinderConfig]):
         # Insert discovered relays as candidates
         if relays:
             try:
-                found = await upsert_candidates(self._brotr, relays.values())
+                found = await insert_candidates(self._brotr, relays.values())
             except (asyncpg.PostgresError, OSError) as e:
                 self._logger.error(
                     "insert_candidates_failed",
@@ -480,7 +480,7 @@ class Finder(BaseService[FinderConfig]):
         sequentially (with a configurable delay between requests),
         deduplicates the results, and inserts discovered URLs as
         validation candidates via
-        [upsert_candidates][bigbrotr.services.common.queries.upsert_candidates].
+        [insert_candidates][bigbrotr.services.common.queries.insert_candidates].
         """
         relays: dict[str, Relay] = {}  # url -> Relay for deduplication
         sources_checked = 0
@@ -530,7 +530,7 @@ class Finder(BaseService[FinderConfig]):
         # Insert as validation candidates (service_name='validator')
         if relays:
             try:
-                self._found_relays += await upsert_candidates(self._brotr, relays.values())
+                self._found_relays += await insert_candidates(self._brotr, relays.values())
             except (asyncpg.PostgresError, OSError) as e:
                 self._logger.error(
                     "insert_candidates_failed",

--- a/tests/unit/models/test_service_state.py
+++ b/tests/unit/models/test_service_state.py
@@ -177,7 +177,7 @@ class TestServiceStateToDbParams:
         assert params.service_name is ServiceName.FINDER
         assert params.state_type is ServiceStateType.CANDIDATE
         assert params.state_key == "wss://nos.lol"
-        assert params.state_value == {"source": "nip65"}
+        assert params.state_value == '{"source": "nip65"}'
         assert params.updated_at == 1700000999
 
     def test_caching(self):
@@ -220,7 +220,7 @@ class TestServiceStateFromDbParams:
             service_name="monitor",  # type: ignore[arg-type]
             state_type="checkpoint",  # type: ignore[arg-type]
             state_key="health_batch",
-            state_value={"completed": 100},
+            state_value='{"completed": 100}',
             updated_at=1700000500,
         )
         state = ServiceState.from_db_params(params)

--- a/tests/unit/services/test_finder.py
+++ b/tests/unit/services/test_finder.py
@@ -379,8 +379,6 @@ class TestFinderFindFromApi:
 
     async def test_find_from_api_success(self, mock_brotr: Brotr) -> None:
         """Test successful API fetch."""
-        mock_brotr.upsert_service_state = AsyncMock(return_value=2)  # type: ignore[method-assign]
-
         config = FinderConfig(
             api=ApiConfig(
                 enabled=True,
@@ -392,7 +390,14 @@ class TestFinderFindFromApi:
 
         mock_response = _mock_api_response(["wss://relay1.com", "wss://relay2.com"])
 
-        with patch("aiohttp.ClientSession") as mock_session_cls:
+        with (
+            patch("aiohttp.ClientSession") as mock_session_cls,
+            patch(
+                "bigbrotr.services.finder.insert_candidates",
+                new_callable=AsyncMock,
+                return_value=2,
+            ),
+        ):
             mock_session = MagicMock()
             mock_session.get = MagicMock(return_value=mock_response)
             mock_session.__aenter__ = AsyncMock(return_value=mock_session)
@@ -550,12 +555,12 @@ class TestFinderFindFromEvents:
                 "bigbrotr.services.finder.get_events_with_relay_urls", new_callable=AsyncMock
             ) as mock_get_events,
             patch(
-                "bigbrotr.services.finder.upsert_candidates", new_callable=AsyncMock
-            ) as mock_upsert,
+                "bigbrotr.services.finder.insert_candidates", new_callable=AsyncMock
+            ) as mock_insert,
         ):
             mock_get_relay_urls.return_value = ["wss://source.relay.com"]
             mock_get_events.side_effect = [[mock_event], []]
-            mock_upsert.return_value = 1
+            mock_insert.return_value = 1
 
             mock_brotr.get_service_state = AsyncMock(return_value=[])  # type: ignore[method-assign]
             mock_brotr.upsert_service_state = AsyncMock(return_value=1)  # type: ignore[method-assign]
@@ -563,9 +568,9 @@ class TestFinderFindFromEvents:
             finder = Finder(brotr=mock_brotr)
             await finder._find_from_events()
 
-            mock_upsert.assert_called()
+            mock_insert.assert_called()
             all_urls = []
-            for call in mock_upsert.call_args_list:
+            for call in mock_insert.call_args_list:
                 relays = call[0][1]
                 for relay in relays:
                     all_urls.append(relay.url)
@@ -590,12 +595,12 @@ class TestFinderFindFromEvents:
                 "bigbrotr.services.finder.get_events_with_relay_urls", new_callable=AsyncMock
             ) as mock_get_events,
             patch(
-                "bigbrotr.services.finder.upsert_candidates", new_callable=AsyncMock
-            ) as mock_upsert,
+                "bigbrotr.services.finder.insert_candidates", new_callable=AsyncMock
+            ) as mock_insert,
         ):
             mock_get_relay_urls.return_value = ["wss://source.relay.com"]
             mock_get_events.side_effect = [[mock_event], []]
-            mock_upsert.return_value = 2
+            mock_insert.return_value = 2
 
             mock_brotr.get_service_state = AsyncMock(return_value=[])  # type: ignore[method-assign]
             mock_brotr.upsert_service_state = AsyncMock(return_value=2)  # type: ignore[method-assign]
@@ -603,9 +608,9 @@ class TestFinderFindFromEvents:
             finder = Finder(brotr=mock_brotr)
             await finder._find_from_events()
 
-            mock_upsert.assert_called()
+            mock_insert.assert_called()
             all_urls = []
-            for call in mock_upsert.call_args_list:
+            for call in mock_insert.call_args_list:
                 relays = call[0][1]
                 for relay in relays:
                     all_urls.append(relay.url)
@@ -631,12 +636,12 @@ class TestFinderFindFromEvents:
                 "bigbrotr.services.finder.get_events_with_relay_urls", new_callable=AsyncMock
             ) as mock_get_events,
             patch(
-                "bigbrotr.services.finder.upsert_candidates", new_callable=AsyncMock
-            ) as mock_upsert,
+                "bigbrotr.services.finder.insert_candidates", new_callable=AsyncMock
+            ) as mock_insert,
         ):
             mock_get_relay_urls.return_value = ["wss://source.relay.com"]
             mock_get_events.side_effect = [[mock_event], []]
-            mock_upsert.return_value = 1
+            mock_insert.return_value = 1
 
             mock_brotr.get_service_state = AsyncMock(return_value=[])  # type: ignore[method-assign]
             mock_brotr.upsert_service_state = AsyncMock(return_value=1)  # type: ignore[method-assign]
@@ -644,9 +649,9 @@ class TestFinderFindFromEvents:
             finder = Finder(brotr=mock_brotr)
             await finder._find_from_events()
 
-            mock_upsert.assert_called()
+            mock_insert.assert_called()
             all_urls = []
-            for call in mock_upsert.call_args_list:
+            for call in mock_insert.call_args_list:
                 relays = call[0][1]
                 for relay in relays:
                     all_urls.append(relay.url)
@@ -671,12 +676,12 @@ class TestFinderFindFromEvents:
                 "bigbrotr.services.finder.get_events_with_relay_urls", new_callable=AsyncMock
             ) as mock_get_events,
             patch(
-                "bigbrotr.services.finder.upsert_candidates", new_callable=AsyncMock
-            ) as mock_upsert,
+                "bigbrotr.services.finder.insert_candidates", new_callable=AsyncMock
+            ) as mock_insert,
         ):
             mock_get_relay_urls.return_value = ["wss://source.relay.com"]
             mock_get_events.side_effect = [[mock_event], []]
-            mock_upsert.return_value = 0
+            mock_insert.return_value = 0
 
             mock_brotr.get_service_state = AsyncMock(return_value=[])  # type: ignore[method-assign]
             mock_brotr.upsert_service_state = AsyncMock(return_value=0)  # type: ignore[method-assign]
@@ -709,12 +714,12 @@ class TestFinderFindFromEvents:
                 "bigbrotr.services.finder.get_events_with_relay_urls", new_callable=AsyncMock
             ) as mock_get_events,
             patch(
-                "bigbrotr.services.finder.upsert_candidates", new_callable=AsyncMock
-            ) as mock_upsert,
+                "bigbrotr.services.finder.insert_candidates", new_callable=AsyncMock
+            ) as mock_insert,
         ):
             mock_get_relay_urls.return_value = ["wss://source.relay.com"]
             mock_get_events.side_effect = [[mock_event], []]
-            mock_upsert.return_value = 1
+            mock_insert.return_value = 1
 
             mock_brotr.get_service_state = AsyncMock(return_value=[])  # type: ignore[method-assign]
             mock_brotr.upsert_service_state = AsyncMock(return_value=1)  # type: ignore[method-assign]
@@ -723,8 +728,8 @@ class TestFinderFindFromEvents:
             await finder._find_from_events()
 
             # Three duplicate URLs should collapse to a single relay object
-            mock_upsert.assert_called()
-            relays = list(mock_upsert.call_args_list[0][0][1])
+            mock_insert.assert_called()
+            relays = list(mock_insert.call_args_list[0][0][1])
             assert len(relays) == 1
             assert relays[0].url == "wss://duplicate.relay.com"
 
@@ -747,12 +752,12 @@ class TestFinderFindFromEvents:
                 "bigbrotr.services.finder.get_events_with_relay_urls", new_callable=AsyncMock
             ) as mock_get_events,
             patch(
-                "bigbrotr.services.finder.upsert_candidates", new_callable=AsyncMock
-            ) as mock_upsert,
+                "bigbrotr.services.finder.insert_candidates", new_callable=AsyncMock
+            ) as mock_insert,
         ):
             mock_get_relay_urls.return_value = ["wss://source.relay.com"]
             mock_get_events.side_effect = [[mock_event], []]
-            mock_upsert.return_value = 1
+            mock_insert.return_value = 1
 
             mock_brotr.get_service_state = AsyncMock(return_value=[])  # type: ignore[method-assign]
             mock_brotr.upsert_service_state = AsyncMock(return_value=1)  # type: ignore[method-assign]
@@ -800,12 +805,12 @@ class TestFinderFindFromEvents:
                 "bigbrotr.services.finder.get_events_with_relay_urls", new_callable=AsyncMock
             ) as mock_get_events,
             patch(
-                "bigbrotr.services.finder.upsert_candidates", new_callable=AsyncMock
-            ) as mock_upsert,
+                "bigbrotr.services.finder.insert_candidates", new_callable=AsyncMock
+            ) as mock_insert,
         ):
             mock_get_relay_urls.return_value = ["wss://source.relay.com"]
             mock_get_events.side_effect = [[mock_event], []]
-            mock_upsert.return_value = 2
+            mock_insert.return_value = 2
 
             mock_brotr.get_service_state = AsyncMock(return_value=[])  # type: ignore[method-assign]
             mock_brotr.upsert_service_state = AsyncMock(return_value=2)  # type: ignore[method-assign]
@@ -813,7 +818,7 @@ class TestFinderFindFromEvents:
             finder = Finder(brotr=mock_brotr)
             await finder._find_from_events()
 
-            mock_upsert.assert_called()
+            mock_insert.assert_called()
 
 
 # ============================================================================

--- a/tests/unit/services/test_validator.py
+++ b/tests/unit/services/test_validator.py
@@ -709,39 +709,6 @@ class TestCleanup:
 
 
 # ============================================================================
-# _parse_delete_result Tests
-# ============================================================================
-
-
-class TestParseDeleteResult:
-    """Tests for Validator._parse_delete_result edge cases."""
-
-    def test_standard_delete_result(self) -> None:
-        assert Validator._parse_delete_result("DELETE 5") == 5
-
-    def test_zero_deleted(self) -> None:
-        assert Validator._parse_delete_result("DELETE 0") == 0
-
-    def test_large_count(self) -> None:
-        assert Validator._parse_delete_result("DELETE 99999") == 99999
-
-    def test_none_returns_zero(self) -> None:
-        assert Validator._parse_delete_result(None) == 0
-
-    def test_empty_string_returns_zero(self) -> None:
-        assert Validator._parse_delete_result("") == 0
-
-    def test_non_numeric_suffix_returns_zero(self) -> None:
-        assert Validator._parse_delete_result("DELETE abc") == 0
-
-    def test_single_word_returns_zero(self) -> None:
-        assert Validator._parse_delete_result("DELETE") == 0
-
-    def test_unexpected_format_returns_zero(self) -> None:
-        assert Validator._parse_delete_result("SOMETHING ELSE") == 0
-
-
-# ============================================================================
 # Network Configuration Tests
 # ============================================================================
 


### PR DESCRIPTION
## Summary

- **Brotr**: replace redundant `pool.transaction()` wrappers with `_call_procedure()` for all 7 insert/upsert/delete methods — single stored procedure calls are already atomic in PostgreSQL, and the transaction wrapper bypassed Pool's retry-with-backoff on transient connection errors
- **ServiceState**: pre-serialize `state_value` to JSON string in `ServiceStateDbParams`, aligning with `EventDbParams.tags` and `MetadataDbParams.data` — removes the `::jsonb[]` cast hack in `upsert_service_state`
- **Candidate lifecycle**: rename `upsert_candidates` → `insert_candidates` and internalize `filter_new_relay_urls` deduplication, simplifying Seeder and Finder callers; `delete_stale_candidates` / `delete_exhausted_candidates` now return `int` directly, removing `_parse_delete_result` from Validator
- **Transport**: replace async-unsafe `threading.Lock` with a reference-counted stderr suppressor that doesn't block the event loop under concurrent async tasks

## Test plan

- [x] `ruff check` — zero errors
- [x] `mypy src/bigbrotr` — zero errors
- [x] `pytest tests/ --ignore=tests/integration/` — 2185 passed
- [x] All pre-commit hooks pass