### PR TITLE
fix: make SSL validation conditional on successful extraction

### DIFF
--- a/src/bigbrotr/nips/nip66/ssl.py
+++ b/src/bigbrotr/nips/nip66/ssl.py
@@ -236,8 +236,10 @@ class Nip66SslMetadata(BaseNipMetadata):
             Dictionary of extracted SSL fields including ``ssl_valid``.
         """
         result: dict[str, Any] = {}
-        result.update(Nip66SslMetadata._extract_certificate_data(host, port, timeout))
-        result["ssl_valid"] = Nip66SslMetadata._validate_certificate(host, port, timeout)
+        cert_data = Nip66SslMetadata._extract_certificate_data(host, port, timeout)
+        result.update(cert_data)
+        if cert_data:
+            result["ssl_valid"] = Nip66SslMetadata._validate_certificate(host, port, timeout)
         return result
 
     @staticmethod

--- a/tests/unit/nips/nip66/test_ssl.py
+++ b/tests/unit/nips/nip66/test_ssl.py
@@ -392,8 +392,8 @@ class TestNip66SslMetadataSslSync:
         assert result.get("ssl_cipher_bits") == 256
         assert result.get("ssl_san") == ["relay.example.com", "*.example.com"]
 
-    def test_ssl_error_returns_invalid(self) -> None:
-        """SSL error returns ssl_valid=False."""
+    def test_ssl_error_returns_empty(self) -> None:
+        """SSL error during extraction skips validation, returns empty dict."""
         import ssl as ssl_module
 
         with patch("socket.create_connection") as mock_conn:
@@ -405,14 +405,16 @@ class TestNip66SslMetadataSslSync:
                 mock_ctx.return_value.wrap_socket.side_effect = ssl_module.SSLError()
                 result = Nip66SslMetadata._ssl("example.com", 443, 30.0)
 
-        assert result.get("ssl_valid") is False
+        assert result == {}
+        assert "ssl_valid" not in result
 
-    def test_connection_error_returns_invalid(self) -> None:
-        """Connection error returns ssl_valid=False."""
+    def test_connection_error_returns_empty(self) -> None:
+        """Connection error during extraction skips validation, returns empty dict."""
         with patch("socket.create_connection", side_effect=TimeoutError()):
             result = Nip66SslMetadata._ssl("example.com", 443, 30.0)
 
-        assert result.get("ssl_valid") is False
+        assert result == {}
+        assert "ssl_valid" not in result
 
 
 class TestNip66SslMetadataSslAsync:


### PR DESCRIPTION
## Summary
- SSL validation now only runs when certificate extraction succeeds
- Prevents `ssl_valid=True` with zero certificate fields when extraction fails but validation connection succeeds

## Changes
- `Nip66SslMetadata._ssl()`: validation conditional on `cert_data` being non-empty
- Updated tests to reflect new behavior (empty dict instead of `ssl_valid=False` on extraction failure)

## Test plan
- [x] Unit tests pass (`43 passed`)
- [x] Pre-commit hooks pass

Closes #209