### PR TITLE
fix: catch tldextract exceptions in DNS test

### DIFF
--- a/src/bigbrotr/nips/nip66/dns.py
+++ b/src/bigbrotr/nips/nip66/dns.py
@@ -127,8 +127,11 @@ class Nip66DnsMetadata(BaseNipMetadata):
 
         # NS records (resolved against the registered domain)
         with contextlib.suppress(*_dns_errors):
-            ext = tldextract.extract(host)
-            if ext.domain and ext.suffix:
+            try:
+                ext = tldextract.extract(host)
+            except Exception:
+                ext = None
+            if ext and ext.domain and ext.suffix:
                 domain = f"{ext.domain}.{ext.suffix}"
                 answers = resolver.resolve(domain, "NS")
                 ns_list = [str(cast("NS", rdata).target).rstrip(".") for rdata in answers]


### PR DESCRIPTION
## Summary
- Wrap `tldextract.extract()` in try/except to prevent uncaught exceptions from crashing DNS test

## Changes
- `nips/nip66/dns.py`: tldextract call wrapped in broad try/except, returns None on failure

## Test plan
- [x] Unit tests pass (17 passed)
- [x] Pre-commit hooks pass

Closes #210