### PR TITLE
fix: unify reason validation to falsy check across all log classes

### DIFF
--- a/src/bigbrotr/nips/nip66/logs.py
+++ b/src/bigbrotr/nips/nip66/logs.py
@@ -65,7 +65,7 @@ class Nip66RttMultiPhaseLogs(BaseModel):
         # Open phase
         if self.open_success and self.open_reason is not None:
             raise ValueError("open_reason must be None when open_success is True")
-        if not self.open_success and self.open_reason is None:
+        if not self.open_success and not self.open_reason:
             raise ValueError("open_reason is required when open_success is False")
 
         # Cascading failure: open failure implies read/write failure
@@ -79,14 +79,14 @@ class Nip66RttMultiPhaseLogs(BaseModel):
         if self.read_success is not None:
             if self.read_success and self.read_reason is not None:
                 raise ValueError("read_reason must be None when read_success is True")
-            if not self.read_success and self.read_reason is None:
+            if not self.read_success and not self.read_reason:
                 raise ValueError("read_reason is required when read_success is False")
 
         # Write phase (if present)
         if self.write_success is not None:
             if self.write_success and self.write_reason is not None:
                 raise ValueError("write_reason must be None when write_success is True")
-            if not self.write_success and self.write_reason is None:
+            if not self.write_success and not self.write_reason:
                 raise ValueError("write_reason is required when write_success is False")
 
         return self

--- a/src/bigbrotr/nips/nip66/rtt.py
+++ b/src/bigbrotr/nips/nip66/rtt.py
@@ -240,7 +240,7 @@ class Nip66RttMetadata(BaseNipMetadata):
             logger.debug("rtt_open_ok relay=%s rtt_open_ms=%s", relay.url, rtt_open)
             return client, rtt_open
         except (OSError, TimeoutError, NostrSdkError, ValueError) as e:
-            reason = str(e)
+            reason = str(e) or type(e).__name__
             logger.debug("rtt_open_failed relay=%s reason=%s", relay.url, reason)
             # Cascading failure: mark all phases as failed
             logs["open_success"] = False


### PR DESCRIPTION
## Summary
- Unified reason field validation to falsy check (rejects empty strings) across BaseLogs and Nip66RttMultiPhaseLogs
- Added `str(e) or type(e).__name__` fallback for exceptions with empty string representations

## Changes
- `nips/nip66/logs.py`: Changed 3 `is None` checks to `not` (falsy) checks
- `nips/nip66/rtt.py`: Added type-name fallback for empty exception messages

## Test plan
- [x] Unit tests pass (63 passed)
- [x] Pre-commit hooks pass

Closes #211