### PR TITLE
fix: remove unused stagger_delay config from Synchronizer

### DIFF
--- a/deployments/lilbrotr/config/services/synchronizer.yaml
+++ b/deployments/lilbrotr/config/services/synchronizer.yaml
@@ -29,5 +29,4 @@ networks:
   loki:
     max_tasks: 2                   # Reduced concurrency (default: 5)
 
-concurrency:
-  stagger_delay: [0, 30]           # Shorter delay range (default: [0, 60])
+concurrency: {}

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -637,7 +637,6 @@ timeouts:
 concurrency:
   max_parallel: 10                           # Concurrent relays per process
   cursor_flush_interval: 50                  # Flush cursors every N relays
-  stagger_delay: [0, 60]                     # Random delay range [min, max] seconds
 
 source:
   from_database: true                        # Fetch relay list from database
@@ -682,7 +681,6 @@ overrides: []                                # Per-relay timeout overrides
 |-------|------|---------|-------|-------------|
 | `concurrency.max_parallel` | int | `10` | 1-100 | Concurrent relays per process |
 | `concurrency.cursor_flush_interval` | int | `50` | - | Flush cursors every N relays |
-| `concurrency.stagger_delay` | list[int] | `[0, 60]` | - | Random delay range [min, max] seconds |
 
 ### Source Reference
 
@@ -769,7 +767,6 @@ pool:
 interval: 300.0
 concurrency:
   max_parallel: 50
-  stagger_delay: [0, 30]
 source:
   from_database: true
 ```

--- a/docs/user-guide/pipeline.md
+++ b/docs/user-guide/pipeline.md
@@ -361,7 +361,6 @@ class EventBatch:
 | `time_range.use_relay_state` | bool | `true` | Use per-relay incremental cursors |
 | `time_range.lookback_seconds` | int | `86400` | Lookback window from cursor position |
 | `concurrency.max_parallel` | int | `10` | Concurrent relays |
-| `concurrency.stagger_delay` | list[int] | `[0, 60]` | Random delay range [min, max] seconds |
 | `source.from_database` | bool | `true` | Fetch relay list from database |
 | `networks` | NetworkConfig | -- | Per-network timeouts and concurrency |
 

--- a/src/bigbrotr/services/synchronizer/configs.py
+++ b/src/bigbrotr/services/synchronizer/configs.py
@@ -142,9 +142,6 @@ class ConcurrencyConfig(BaseModel):
     cursor_flush_interval: int = Field(
         default=50, ge=1, description="Flush cursor updates every N relays"
     )
-    stagger_delay: tuple[int, int] = Field(
-        default=(0, 60), description="Random delay range (min, max) seconds"
-    )
 
 
 class SourceConfig(BaseModel):

--- a/src/bigbrotr/services/synchronizer/service.py
+++ b/src/bigbrotr/services/synchronizer/service.py
@@ -21,9 +21,9 @@ Note:
     with ``state_type='cursor'``. Cursor updates are batched (flushed
     every ``cursor_flush_interval`` relays) for crash resilience.
 
-    The stagger delay (``concurrency.stagger_delay``) randomizes the
-    relay processing order to avoid thundering-herd effects when multiple
-    synchronizer instances run concurrently.
+    Relay processing order is randomized (shuffled) to avoid
+    thundering-herd effects when multiple synchronizer instances run
+    concurrently.
 
 See Also:
     [SynchronizerConfig][bigbrotr.services.synchronizer.SynchronizerConfig]:

--- a/tests/unit/services/test_synchronizer.py
+++ b/tests/unit/services/test_synchronizer.py
@@ -231,7 +231,6 @@ class TestConcurrencyConfig:
         """Test default concurrency config."""
         config = ConcurrencyConfig()
 
-        assert config.stagger_delay == (0, 60)
         assert config.cursor_flush_interval == 50
 
 


### PR DESCRIPTION
## Summary
- Removed dead `stagger_delay` field from `SynchronizerConcurrencyConfig`
- Relay order randomization via `random.shuffle()` is sufficient

## Changes
- `services/synchronizer/configs.py`: Removed `stagger_delay` field
- `services/synchronizer/service.py`: Updated docstring
- `tests/unit/services/test_synchronizer.py`: Removed stagger_delay assertion
- `deployments/lilbrotr/config/services/synchronizer.yaml`: Removed stagger_delay config
- `docs/user-guide/configuration.md` and `pipeline.md`: Removed stagger_delay references

## Test plan
- [x] Unit tests pass
- [x] Pre-commit hooks pass

Closes #213