### PR TITLE
fix: wrap one-shot mode in service context manager

### DIFF
--- a/src/bigbrotr/__main__.py
+++ b/src/bigbrotr/__main__.py
@@ -91,7 +91,8 @@ async def run_service(
     # One-shot mode: single cycle, no metrics server
     if once:
         try:
-            await service.run()
+            async with service:
+                await service.run()
             logger.info(f"{service_name}_completed")
             return 0
         except Exception as e:  # Intentionally broad: CLI error boundary for one-shot mode


### PR DESCRIPTION
## Summary
- One-shot mode now uses `async with service:` for proper lifecycle management

## Test plan
- [x] Unit tests pass (65 passed)
- [x] Pre-commit hooks pass

Closes #218