### PR TITLE
fix: remove dead exception catch in GeoIP _geo()

### DIFF
--- a/src/bigbrotr/nips/nip66/geo.py
+++ b/src/bigbrotr/nips/nip66/geo.py
@@ -173,14 +173,14 @@ class Nip66GeoMetadata(BaseNipMetadata):
             geohash_precision: Geohash encoding precision (1-12, default 9).
 
         Returns:
-            Dictionary of geolocation fields, or empty dict on error.
+            Dictionary of geolocation fields.
+
+        Raises:
+            geoip2.errors.GeoIP2Error: GeoIP database lookup failure.
+            ValueError: Invalid IP address or database response.
         """
-        try:
-            response = city_reader.city(ip)
-            return GeoExtractor.extract_all(response, geohash_precision=geohash_precision)
-        except (geoip2.errors.GeoIP2Error, ValueError) as e:
-            logger.debug("geo_geoip_lookup_error ip=%s error=%s", ip, str(e))
-            return {}
+        response = city_reader.city(ip)
+        return GeoExtractor.extract_all(response, geohash_precision=geohash_precision)
 
     @classmethod
     async def execute(

--- a/tests/unit/nips/nip66/test_geo.py
+++ b/tests/unit/nips/nip66/test_geo.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from bigbrotr.models import Relay
 from bigbrotr.nips.nip66.geo import GeoExtractor, Nip66GeoMetadata
 
@@ -363,14 +365,13 @@ class TestNip66GeoMetadataGeoSync:
         assert result["geo_city"] == "Mountain View"
         mock_city_reader.city.assert_called_once_with("8.8.8.8")
 
-    def test_lookup_exception_returns_empty_dict(self) -> None:
-        """Lookup exception returns empty dict."""
+    def test_lookup_exception_propagates(self) -> None:
+        """Lookup exception propagates to caller."""
         mock_city_reader = MagicMock()
         mock_city_reader.city.side_effect = ValueError("IP not found")
 
-        result = Nip66GeoMetadata._geo("192.168.1.1", mock_city_reader)
-
-        assert result == {}
+        with pytest.raises(ValueError, match="IP not found"):
+            Nip66GeoMetadata._geo("192.168.1.1", mock_city_reader)
 
     def test_lookup_with_different_ip(self, mock_geoip_response: MagicMock) -> None:
         """Lookup with IPv6 address."""


### PR DESCRIPTION
## Summary

- Remove the inner `try/except` in `Nip66GeoMetadata._geo()` that swallowed `GeoIP2Error`/`ValueError` and returned `{}`, making the outer catch in `execute()` unreachable dead code
- Exceptions now propagate to `execute()`, which catches them and preserves the specific error reason in logs instead of the generic "no geo data found for IP"
- Update test to verify exception propagation behavior

## Test plan

- [x] `ruff check` passes
- [x] `mypy` passes (strict)
- [x] All 33 geo tests pass (`tests/unit/nips/nip66/test_geo.py`)
- [x] Full unit test suite passes (2338 tests)
- [x] Pre-commit hooks pass

Closes #222