### PR TITLE
fix: use int timestamp consistently in _publish_if_due

### DIFF
--- a/src/bigbrotr/services/monitor/service.py
+++ b/src/bigbrotr/services/monitor/service.py
@@ -789,7 +789,7 @@ class Monitor(
             ServiceStateType.CHECKPOINT,
             state_key,
         )
-        last_ts = results[0].state_value.get("timestamp", 0.0) if results else 0.0
+        last_ts = results[0].state_value.get("timestamp", 0) if results else 0
         if time.time() - last_ts < interval:
             return
 
@@ -804,7 +804,7 @@ class Monitor(
             return
 
         self._logger.info("publish_completed", event=event_name, relays=sent)
-        now = time.time()
+        now = int(time.time())
         await self._brotr.upsert_service_state(
             [
                 ServiceState(
@@ -812,7 +812,7 @@ class Monitor(
                     state_type=ServiceStateType.CHECKPOINT,
                     state_key=state_key,
                     state_value={"timestamp": now},
-                    updated_at=int(now),
+                    updated_at=now,
                 ),
             ]
         )


### PR DESCRIPTION
## Summary
- Change `now = time.time()` to `now = int(time.time())` in `_publish_if_due`
- Remove redundant `int()` cast on `updated_at` since `now` is already int
- Change default fallback from `0.0` to `0` for consistency with int timestamps
- Aligns with the int timestamp pattern used in `_save_results` and all other services

## Test plan
- [x] `tests/unit/services/test_monitor.py` -- 91 tests pass
- [x] `ruff check` clean
- [x] `mypy` clean
- [x] All pre-commit hooks pass

Closes #225