### PR TITLE
fix: add health check condition to Grafana depends_on

### DIFF
--- a/deployments/bigbrotr/docker-compose.yaml
+++ b/deployments/bigbrotr/docker-compose.yaml
@@ -684,7 +684,8 @@ services:
       - bigbrotr-monitoring-network
 
     depends_on:
-      - prometheus
+      prometheus:
+        condition: service_healthy
 
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health"]


### PR DESCRIPTION
## Summary
- Change Grafana's `depends_on` from short form to long form with `condition: service_healthy`
- Matches the existing lilbrotr deployment pattern

## Test plan
- [ ] `docker compose config` validates without errors
- [ ] Consistent with lilbrotr's Grafana `depends_on`

Closes #231