### PR TITLE
fix: return tuple from deep_freeze for true immutability

### DIFF
--- a/src/bigbrotr/models/_validation.py
+++ b/src/bigbrotr/models/_validation.py
@@ -131,5 +131,5 @@ def deep_freeze(obj: Any) -> Any:
     if isinstance(obj, dict):
         return MappingProxyType({k: deep_freeze(v) for k, v in obj.items()})
     if isinstance(obj, list):
-        return [deep_freeze(item) for item in obj]
+        return tuple(deep_freeze(item) for item in obj)
     return obj

--- a/tests/unit/models/test_metadata.py
+++ b/tests/unit/models/test_metadata.py
@@ -100,8 +100,8 @@ class TestConstruction:
         m = Metadata(
             type=MetadataType.NIP11_INFO, data={"items": [1, 2, 3], "names": ["a", "b", "c"]}
         )
-        assert m.data["items"] == [1, 2, 3]
-        assert m.data["names"] == ["a", "b", "c"]
+        assert m.data["items"] == (1, 2, 3)
+        assert m.data["names"] == ("a", "b", "c")
 
     def test_with_mixed_types(self):
         """Constructs with mixed value types (None is filtered out)."""
@@ -252,7 +252,7 @@ class TestFromDbParams:
             id=hash_bytes, type=MetadataType.NIP66_RTT, data='{"a": {"b": [1, 2, 3]}}'
         )
         m = Metadata.from_db_params(params)
-        assert m.data["a"]["b"] == [1, 2, 3]
+        assert m.data["a"]["b"] == (1, 2, 3)
         assert m.type == MetadataType.NIP66_RTT
 
     def test_empty(self):
@@ -339,7 +339,7 @@ class TestEdgeCases:
         m = Metadata(type=MetadataType.NIP11_INFO, data=data)
         params = m.to_db_params()
         reconstructed = Metadata.from_db_params(params)
-        assert reconstructed.data == data
+        assert reconstructed.data == {"items": tuple(range(10000))}
 
     def test_special_json_characters(self):
         """Special JSON characters are escaped."""
@@ -468,12 +468,12 @@ class TestNormalization:
     def test_empty_in_lists_removed(self):
         """Empty containers within lists are removed."""
         m = Metadata(type=MetadataType.NIP11_INFO, data={"items": [1, [], 2, {}, 3]})
-        assert m.data == {"items": [1, 2, 3]}
+        assert m.data == {"items": (1, 2, 3)}
 
     def test_none_in_lists_removed(self):
         """None values within lists are removed."""
         m = Metadata(type=MetadataType.NIP11_INFO, data={"items": [1, None, 2, None, 3]})
-        assert m.data == {"items": [1, 2, 3]}
+        assert m.data == {"items": (1, 2, 3)}
 
     def test_falsy_values_preserved(self):
         """Falsy values (False, 0, '') are preserved, only None/empty containers removed."""

--- a/tests/unit/models/test_validation.py
+++ b/tests/unit/models/test_validation.py
@@ -272,12 +272,18 @@ class TestDeepFreeze:
 
     def test_list_contents_frozen(self) -> None:
         result = deep_freeze({"items": [{"a": 1}]})
+        assert isinstance(result["items"], tuple)
         assert isinstance(result["items"][0], MappingProxyType)
 
-    def test_list_preserved_as_list(self) -> None:
+    def test_list_rejects_mutation(self) -> None:
+        result = deep_freeze({"items": [1, 2, 3]})
+        with pytest.raises(TypeError):
+            result["items"][0] = 99  # type: ignore[index]
+
+    def test_list_becomes_tuple(self) -> None:
         result = deep_freeze([1, 2, 3])
-        assert isinstance(result, list)
-        assert result == [1, 2, 3]
+        assert isinstance(result, tuple)
+        assert result == (1, 2, 3)
 
     def test_primitives_unchanged(self) -> None:
         assert deep_freeze(42) == 42
@@ -292,4 +298,5 @@ class TestDeepFreeze:
 
     def test_empty_list(self) -> None:
         result = deep_freeze([])
-        assert result == []
+        assert isinstance(result, tuple)
+        assert result == ()


### PR DESCRIPTION
## Summary
- `deep_freeze` returned a list comprehension for list inputs, leaving sequences mutable inside frozen dataclasses
- Changed to return `tuple` instead, ensuring lists are fully immutable after freezing
- Updated all affected test assertions to compare against tuples

## Test plan
- [x] All 2339 unit tests pass
- [x] `ruff check` clean
- [x] `mypy` strict clean
- [x] Pre-commit hooks pass

Closes #265