### PR TITLE
docs: fix procedure name case-sensitivity docstring

### DIFF
--- a/src/bigbrotr/core/brotr.py
+++ b/src/bigbrotr/core/brotr.py
@@ -325,7 +325,7 @@ class Brotr:
 
         Args:
             procedure_name: Name of the stored procedure. Must match
-                ``[a-z_][a-z0-9_]*`` (case-insensitive).
+                ``[a-z_][a-z0-9_]*``.
             *args: Arguments passed as parameterized query values.
             fetch_result: If ``True``, return the scalar result (defaulting
                 to ``0`` for ``None``). If ``False``, execute without returning.


### PR DESCRIPTION
## Summary
- Remove "(case-insensitive)" from `_call_procedure` docstring
- The regex `[a-z_][a-z0-9_]*` only allows lowercase, so procedure names are case-sensitive by definition

## Test plan
- [x] `tests/unit/core/test_brotr.py` pass (76/76)
- [x] ruff + mypy clean

Closes #243