### PR TITLE
fix: exclude raw_url from Relay equality comparison

### DIFF
--- a/src/bigbrotr/models/relay.py
+++ b/src/bigbrotr/models/relay.py
@@ -118,7 +118,7 @@ class Relay:
             to an [Event][bigbrotr.models.event.Event].
     """
 
-    raw_url: str = field(repr=False)
+    raw_url: str = field(repr=False, compare=False)
     discovered_at: int = field(default_factory=lambda: int(time()))
 
     url: str = field(init=False)


### PR DESCRIPTION
## Summary
- Add `compare=False` to `raw_url` field so equality uses only the normalized `url`

## Test plan
- [ ] `tests/unit/models/test_relay.py` pass
- [ ] `ruff check` and `mypy` clean

Closes #241