### PR TITLE
fix: deduplicate supported_nips in NIP-11 parsing

### DIFF
--- a/src/bigbrotr/nips/nip11/data.py
+++ b/src/bigbrotr/nips/nip11/data.py
@@ -338,7 +338,7 @@ class Nip11InfoData(BaseData):
                 n for n in data["supported_nips"] if isinstance(n, int) and not isinstance(n, bool)
             ]
             if nips:
-                result["supported_nips"] = nips
+                result["supported_nips"] = sorted(set(nips))
 
         result.update(cls._parse_sub_objects(data))
         return result


### PR DESCRIPTION
## Summary
- Deduplicate `supported_nips` in NIP-11 parsing via `sorted(set(nips))`
- Prevents duplicate N tags in Kind 30166 events

## Test plan
- [x] `tests/unit/nips/nip11/` pass (255 tests)
- [x] `ruff check` clean
- [x] `mypy` clean

Closes #246