### PR TITLE
fix: catch KeyError in models_from_dict

### DIFF
--- a/src/bigbrotr/utils/parsing.py
+++ b/src/bigbrotr/utils/parsing.py
@@ -66,7 +66,7 @@ def models_from_dict(
     for row in rows:
         try:
             results.append(factory(row))
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, KeyError):
             logger.warning("parse_failed row=%s", row)
     return results
 


### PR DESCRIPTION
## Summary
- Add `KeyError` to the exception tuple in `models_from_dict` so a missing dict key in a factory lambda skips the row instead of crashing the entire batch
- Update test to assert the new catch-and-skip behavior
- Move `import pytest` into `TYPE_CHECKING` block (no remaining runtime usages after removing `pytest.raises`)

## Test plan
- [x] `ruff check` clean
- [x] `mypy` clean
- [x] `tests/unit/utils/` -- 177 tests pass
- [x] All pre-commit hooks pass

Closes #250