### PR TITLE
test: relax exact mock call count assertions in Event tests

### DIFF
--- a/tests/unit/models/test_event.py
+++ b/tests/unit/models/test_event.py
@@ -269,57 +269,49 @@ class TestSlots:
 
 
 class TestDelegation:
-    """Method delegation to wrapped NostrEvent via __getattr__.
-
-    Most methods are called multiple times because __post_init__ performs
-    fail-fast validation via to_db_params() and null byte checks.
-    """
+    """Method delegation to wrapped NostrEvent via __getattr__."""
 
     def test_id_delegates(self, mock_nostr_event):
         """id() delegates to wrapped event."""
         event = Event(mock_nostr_event)
         event.id()
-        # 3x: null check, to_db_params in __post_init__, explicit call
-        assert mock_nostr_event.id.call_count == 3
+        assert mock_nostr_event.id.call_count >= 1
 
     def test_author_delegates(self, mock_nostr_event):
         """author() delegates to wrapped event."""
         event = Event(mock_nostr_event)
         event.author()
-        # 2x: to_db_params in __post_init__, explicit call
-        assert mock_nostr_event.author.call_count == 2
+        assert mock_nostr_event.author.call_count >= 1
 
     def test_created_at_delegates(self, mock_nostr_event):
         """created_at() delegates to wrapped event."""
         event = Event(mock_nostr_event)
         event.created_at()
-        assert mock_nostr_event.created_at.call_count == 2
+        assert mock_nostr_event.created_at.call_count >= 1
 
     def test_kind_delegates(self, mock_nostr_event):
         """kind() delegates to wrapped event."""
         event = Event(mock_nostr_event)
         event.kind()
-        assert mock_nostr_event.kind.call_count == 2
+        assert mock_nostr_event.kind.call_count >= 1
 
     def test_tags_delegates(self, mock_nostr_event):
         """tags() delegates to wrapped event."""
         event = Event(mock_nostr_event)
         event.tags()
-        # 3x: null check, to_db_params in __post_init__, explicit call
-        assert mock_nostr_event.tags.call_count == 3
+        assert mock_nostr_event.tags.call_count >= 1
 
     def test_content_delegates(self, mock_nostr_event):
         """content() delegates to wrapped event."""
         event = Event(mock_nostr_event)
         event.content()
-        # 3x: null check, to_db_params in __post_init__, explicit call
-        assert mock_nostr_event.content.call_count == 3
+        assert mock_nostr_event.content.call_count >= 1
 
     def test_signature_delegates(self, mock_nostr_event):
         """signature() delegates to wrapped event."""
         event = Event(mock_nostr_event)
         event.signature()
-        assert mock_nostr_event.signature.call_count == 2
+        assert mock_nostr_event.signature.call_count >= 1
 
     def test_verify_delegates(self, mock_nostr_event):
         """verify() should delegate to wrapped event."""


### PR DESCRIPTION
## Summary
- Replace exact `call_count == N` assertions with `call_count >= 1` in `TestDelegation`
- Remove implementation-detail comments that described internal `__post_init__` call counts
- Collapse class docstring that referenced implementation-specific call multiplicity

Tests still verify that each method delegates to the wrapped `NostrEvent`, but no longer break when `__post_init__` internals change.

## Test plan
- [x] `pytest tests/unit/models/test_event.py` -- 45/45 passed
- [x] `ruff check` clean
- [x] All pre-commit hooks passed

Closes #256