### PR TITLE
fix: remove duplicate SyncCycleCounters initialization

### DIFF
--- a/src/bigbrotr/services/synchronizer/service.py
+++ b/src/bigbrotr/services/synchronizer/service.py
@@ -136,7 +136,7 @@ class Synchronizer(NetworkSemaphoresMixin, BaseService[SynchronizerConfig]):
         )
 
         cycle_start = time.monotonic()
-        self._counters = SyncCycleCounters()
+        self._counters.reset()
 
         relay_count = await self.synchronize()
 

--- a/src/bigbrotr/services/synchronizer/utils.py
+++ b/src/bigbrotr/services/synchronizer/utils.py
@@ -278,6 +278,13 @@ class SyncCycleCounters:
     skipped_events: int = 0
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
+    def reset(self) -> None:
+        self.synced_events = 0
+        self.synced_relays = 0
+        self.failed_relays = 0
+        self.invalid_events = 0
+        self.skipped_events = 0
+
 
 @dataclass(slots=True)
 class SyncBatchState:


### PR DESCRIPTION
## Summary
- Add `reset()` method to `SyncCycleCounters` to zero all counters in place
- Replace `self._counters = SyncCycleCounters()` in `run()` with `self._counters.reset()`
- The `__init__` initialization remains as the single creation point, `run()` resets per cycle

## Test plan
- [x] `ruff check` clean
- [x] `mypy` clean (4 source files, no issues)
- [x] 57 synchronizer unit tests pass
- [x] All pre-commit hooks pass

Closes #257