### PR TITLE
fix: remove asyncpg from mypy ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,6 @@ strict = true
 
 [[tool.mypy.overrides]]
 module = [
-    "asyncpg.*",
     "nostr_sdk.*",
     "aiohttp_socks.*",
     "aiomultiprocess.*",


### PR DESCRIPTION
## Summary
- Remove `asyncpg.*` from mypy `ignore_missing_imports` overrides
- `asyncpg-stubs` is installed as a dev dependency, so the override was suppressing type-checking benefits from the stubs

## Test plan
- [x] `mypy src/bigbrotr` passes clean (0 issues in 72 files)
- [x] `ruff check src/ tests/` passes
- [x] All 2338 unit tests pass

Closes #259