### PR TITLE
fix: add missing dependencies to pre-commit mypy hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,12 +83,15 @@ repos:
           - aiohttp-socks>=0.9.0
           - aiomultiprocess>=0.9.1
           - asyncpg>=0.29.0
+          - cryptography>=46.0.5
+          - dnspython>=2.5.0
           - geoip2>=4.8.0
           - geohash2>=1.1
           - nostr-sdk>=0.37.0
           - prometheus-client>=0.21.0
           - PyYAML>=6.0.1
           - rfc3986>=2.0.0
+          - tldextract>=5.1.0
           - typing-extensions>=4.9.0
         args: [--config-file=pyproject.toml]
         pass_filenames: false


### PR DESCRIPTION
## Summary
- Add `cryptography`, `dnspython`, and `tldextract` to mypy hook's `additional_dependencies`
- Prevents `import-not-found` errors in isolated pre-commit environment

## Test plan
- [x] `pre-commit run mypy --all-files` passes
- [x] No `import-not-found` errors

Closes #261