### PR TITLE
fix: remove blanket mypy ignore_errors from __main__

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,10 +221,6 @@ ignore_missing_imports = true
 module = "bigbrotr.utils.transport"
 allow_subclassing_any = true
 
-[[tool.mypy.overrides]]
-module = "__main__.*"
-ignore_errors = true
-
 [tool.sqlfluff.core]
 dialect = "postgres"
 templater = "raw"


### PR DESCRIPTION
## Summary
- Remove `ignore_errors = true` override for `__main__.*` in `pyproject.toml`
- The CLI entry point was already type-clean, so no code fixes were needed

## Test plan
- [x] `mypy src/bigbrotr` passes (72 files, 0 errors)
- [x] All 2338 unit tests pass
- [x] `ruff check` passes
- [x] `uv lock --check` passes

Closes #260