### PR TITLE
fix: remove stale skipped_events from SyncCycleCounters.reset()

### DIFF
--- a/src/bigbrotr/services/synchronizer/utils.py
+++ b/src/bigbrotr/services/synchronizer/utils.py
@@ -282,7 +282,6 @@ class SyncCycleCounters:
         self.synced_relays = 0
         self.failed_relays = 0
         self.invalid_events = 0
-        self.skipped_events = 0
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
- Remove `self.skipped_events = 0` from `SyncCycleCounters.reset()` — the field was removed in #297 but the `reset()` method added in #298 still referenced it, causing a mypy slot assignment error on develop.

## Test plan
- [x] `mypy` passes (pre-commit verified)
- [ ] CI green on develop after merge