### PR TITLE
fix: use strict=True in _transpose_to_columns zip

### DIFF
--- a/src/bigbrotr/core/brotr.py
+++ b/src/bigbrotr/core/brotr.py
@@ -305,7 +305,7 @@ class Brotr:
             if len(row) != expected_len:
                 raise ValueError(f"Row {i} has {len(row)} columns, expected {expected_len}")
 
-        return tuple(list(col) for col in zip(*params, strict=False))
+        return tuple(list(col) for col in zip(*params, strict=True))
 
     # Pattern for valid SQL identifiers (prevents injection in procedure calls)
     _VALID_PROCEDURE_NAME: ClassVar[re.Pattern[str]] = re.compile(r"^[a-z_][a-z0-9_]*$")


### PR DESCRIPTION
## Summary
- `_transpose_to_columns` already validates that all rows have equal length, but then calls `zip(*params, strict=False)`. Changed to `strict=True` for defensive consistency.

## Changes
- `src/bigbrotr/core/brotr.py`: `strict=False` → `strict=True` in `zip()` call

## Test Plan
- [x] All 2361 unit tests pass
- [x] ruff + mypy clean
- [x] Pre-commit hooks pass

Closes #242