### PR TITLE
fix: correct matview JSONB paths and add dedicated refresher DB role

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -185,7 +185,7 @@
       {
         "type": "Secret Keyword",
         "filename": "deployments/bigbrotr/config/services/refresher.yaml",
-        "hashed_secret": "af8155550aa71692cfe5f405cd45b9381ae8fbfc",
+        "hashed_secret": "e826d39af6f875b5169c9c45f48e7bdd2b38bd22",
         "is_verified": false,
         "line_number": 10
       }
@@ -257,7 +257,7 @@
       {
         "type": "Secret Keyword",
         "filename": "deployments/lilbrotr/config/services/refresher.yaml",
-        "hashed_secret": "af8155550aa71692cfe5f405cd45b9381ae8fbfc",
+        "hashed_secret": "e826d39af6f875b5169c9c45f48e7bdd2b38bd22",
         "is_verified": false,
         "line_number": 10
       }
@@ -358,5 +358,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-01T09:08:52Z"
+  "generated_at": "2026-03-01T09:12:31Z"
 }

--- a/deployments/bigbrotr/.env.example
+++ b/deployments/bigbrotr/.env.example
@@ -8,9 +8,10 @@
 # ----------------------------------------------------------------------------
 # DATABASE PASSWORDS (REQUIRED)
 # ----------------------------------------------------------------------------
-# DB_ADMIN_PASSWORD:  PostgreSQL admin user (used by postgres + pgbouncer)
-# DB_WRITER_PASSWORD: Writer services (seeder, finder, validator, monitor, synchronizer, refresher)
-# DB_READER_PASSWORD: Read-only services (postgres-exporter, api, dvm)
+# DB_ADMIN_PASSWORD:     PostgreSQL admin user (used by postgres + pgbouncer)
+# DB_WRITER_PASSWORD:    Writer services (seeder, finder, validator, monitor, synchronizer)
+# DB_READER_PASSWORD:    Read-only services (postgres-exporter, api, dvm)
+# DB_REFRESHER_PASSWORD: Refresher service (matview ownership for REFRESH CONCURRENTLY)
 #
 # Generate secure passwords: openssl rand -base64 32
 # Each password MUST be different for role isolation.
@@ -19,6 +20,7 @@
 DB_ADMIN_PASSWORD=
 DB_WRITER_PASSWORD=
 DB_READER_PASSWORD=
+DB_REFRESHER_PASSWORD=
 
 # ----------------------------------------------------------------------------
 # PRIVATE KEY (REQUIRED)

--- a/deployments/bigbrotr/config/services/refresher.yaml
+++ b/deployments/bigbrotr/config/services/refresher.yaml
@@ -6,8 +6,8 @@
 # =============================================================================
 
 pool:
-  user: bigbrotr_writer
-  password_env: DB_WRITER_PASSWORD
+  user: bigbrotr_refresher
+  password_env: DB_REFRESHER_PASSWORD
   max_size: 2
 
 metrics:

--- a/deployments/bigbrotr/docker-compose.yaml
+++ b/deployments/bigbrotr/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
       PGDATA: /var/lib/postgresql/data/pgdata
       DB_WRITER_PASSWORD: ${DB_WRITER_PASSWORD}
       DB_READER_PASSWORD: ${DB_READER_PASSWORD}
+      DB_REFRESHER_PASSWORD: ${DB_REFRESHER_PASSWORD}
 
     volumes:
       - ./data/postgres:/var/lib/postgresql/data                # Persistent data
@@ -76,6 +77,7 @@ services:
       DB_ADMIN_PASSWORD: ${DB_ADMIN_PASSWORD}
       DB_WRITER_PASSWORD: ${DB_WRITER_PASSWORD}
       DB_READER_PASSWORD: ${DB_READER_PASSWORD}
+      DB_REFRESHER_PASSWORD: ${DB_REFRESHER_PASSWORD}
 
     entrypoint: ["/custom-entrypoint.sh"]
 
@@ -502,7 +504,7 @@ services:
     restart: unless-stopped
 
     environment:
-      DB_WRITER_PASSWORD: ${DB_WRITER_PASSWORD}
+      DB_REFRESHER_PASSWORD: ${DB_REFRESHER_PASSWORD}
 
     volumes:
       - ./config:/app/config:ro
@@ -851,7 +853,7 @@ networks:
 # ============================================================================
 #
 # 1. Setup:
-#    cp .env.example .env && nano .env  # Set DB_ADMIN_PASSWORD, DB_WRITER_PASSWORD, DB_READER_PASSWORD, PRIVATE_KEY
+#    cp .env.example .env && nano .env  # Set all DB passwords, PRIVATE_KEY, GRAFANA_PASSWORD
 #
 # 2. Start:
 #    docker-compose up -d

--- a/deployments/bigbrotr/pgbouncer/entrypoint.sh
+++ b/deployments/bigbrotr/pgbouncer/entrypoint.sh
@@ -1,18 +1,20 @@
 #!/bin/sh
 # Generate PgBouncer userlist from environment variables and start PgBouncer.
-# Userlist includes admin (for pool management) + writer/reader application roles.
+# Userlist includes admin (for pool management) + writer/reader/refresher application roles.
 # Role names are derived from POSTGRES_DB environment variable.
 
 set -eu
 
 WRITER_ROLE="${POSTGRES_DB}_writer"
 READER_ROLE="${POSTGRES_DB}_reader"
+REFRESHER_ROLE="${POSTGRES_DB}_refresher"
 
 mkdir -p /tmp/pgbouncer
 cat > /tmp/pgbouncer/userlist.txt <<EOF
 "admin" "${DB_ADMIN_PASSWORD}"
 "${WRITER_ROLE}" "${DB_WRITER_PASSWORD}"
 "${READER_ROLE}" "${DB_READER_PASSWORD}"
+"${REFRESHER_ROLE}" "${DB_REFRESHER_PASSWORD}"
 EOF
 chmod 600 /tmp/pgbouncer/userlist.txt
 

--- a/deployments/bigbrotr/postgres/init/06_materialized_views.sql
+++ b/deployments/bigbrotr/postgres/init/06_materialized_views.sql
@@ -162,9 +162,9 @@ LEFT JOIN event_agg AS ea ON r.url = ea.relay_url
 -- LATERAL join: compute average RTT from the 10 most recent measurements
 LEFT JOIN LATERAL (
     SELECT
-        ROUND(AVG((m.data ->> 'rtt_open')::INTEGER)::NUMERIC, 2) AS avg_rtt_open,
-        ROUND(AVG((m.data ->> 'rtt_read')::INTEGER)::NUMERIC, 2) AS avg_rtt_read,
-        ROUND(AVG((m.data ->> 'rtt_write')::INTEGER)::NUMERIC, 2) AS avg_rtt_write
+        ROUND(AVG((m.data -> 'data' ->> 'rtt_open')::INTEGER)::NUMERIC, 2) AS avg_rtt_open,
+        ROUND(AVG((m.data -> 'data' ->> 'rtt_read')::INTEGER)::NUMERIC, 2) AS avg_rtt_read,
+        ROUND(AVG((m.data -> 'data' ->> 'rtt_write')::INTEGER)::NUMERIC, 2) AS avg_rtt_write
     FROM (
         SELECT
             rm.metadata_id,
@@ -180,9 +180,9 @@ LEFT JOIN LATERAL (
 -- LATERAL join: latest NIP-11 relay info
 LEFT JOIN LATERAL (
     SELECT
-        m.data ->> 'name' AS name,
-        m.data ->> 'software' AS software,
-        m.data ->> 'version' AS version
+        m.data -> 'data' ->> 'name' AS name,
+        m.data -> 'data' ->> 'software' AS software,
+        m.data -> 'data' ->> 'version' AS version
     FROM relay_metadata AS rm
     INNER JOIN metadata AS m ON rm.metadata_id = m.id AND rm.metadata_type = m.metadata_type
     WHERE rm.relay_url = r.url AND rm.metadata_type = 'nip11_info'
@@ -337,13 +337,13 @@ COMMENT ON MATERIALIZED VIEW network_stats IS
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS relay_software_counts AS
 SELECT
-    data ->> 'software' AS software,
-    COALESCE(data ->> 'version', 'unknown') AS version,
+    data -> 'data' ->> 'software' AS software,
+    COALESCE(data -> 'data' ->> 'version', 'unknown') AS version,
     COUNT(*) AS relay_count
 FROM relay_metadata_latest
 WHERE metadata_type = 'nip11_info'
-    AND data ->> 'software' IS NOT NULL
-GROUP BY data ->> 'software', COALESCE(data ->> 'version', 'unknown')
+    AND data -> 'data' ->> 'software' IS NOT NULL
+GROUP BY data -> 'data' ->> 'software', COALESCE(data -> 'data' ->> 'version', 'unknown')
 ORDER BY relay_count DESC;
 
 COMMENT ON MATERIALIZED VIEW relay_software_counts IS
@@ -364,10 +364,10 @@ SELECT
     nip_text::INTEGER AS nip,
     COUNT(*) AS relay_count
 FROM relay_metadata_latest
-CROSS JOIN LATERAL jsonb_array_elements_text(data -> 'supported_nips') AS nip_text
+CROSS JOIN LATERAL jsonb_array_elements_text(data -> 'data' -> 'supported_nips') AS nip_text
 WHERE metadata_type = 'nip11_info'
-    AND data ? 'supported_nips'
-    AND jsonb_typeof(data -> 'supported_nips') = 'array'
+    AND data -> 'data' ? 'supported_nips'
+    AND jsonb_typeof(data -> 'data' -> 'supported_nips') = 'array'
     AND nip_text ~ '^\d+$'
 GROUP BY nip_text::INTEGER
 ORDER BY relay_count DESC;

--- a/deployments/lilbrotr/.env.example
+++ b/deployments/lilbrotr/.env.example
@@ -8,9 +8,10 @@
 # ----------------------------------------------------------------------------
 # DATABASE PASSWORDS (REQUIRED)
 # ----------------------------------------------------------------------------
-# DB_ADMIN_PASSWORD:  PostgreSQL admin user (used by postgres + pgbouncer)
-# DB_WRITER_PASSWORD: Writer services (seeder, finder, validator, monitor, synchronizer, refresher)
-# DB_READER_PASSWORD: Read-only services (postgres-exporter, api, dvm)
+# DB_ADMIN_PASSWORD:     PostgreSQL admin user (used by postgres + pgbouncer)
+# DB_WRITER_PASSWORD:    Writer services (seeder, finder, validator, monitor, synchronizer)
+# DB_READER_PASSWORD:    Read-only services (postgres-exporter, api, dvm)
+# DB_REFRESHER_PASSWORD: Refresher service (matview ownership for REFRESH CONCURRENTLY)
 #
 # Generate secure passwords: openssl rand -base64 32
 # Each password MUST be different for role isolation.
@@ -19,6 +20,7 @@
 DB_ADMIN_PASSWORD=
 DB_WRITER_PASSWORD=
 DB_READER_PASSWORD=
+DB_REFRESHER_PASSWORD=
 
 # ----------------------------------------------------------------------------
 # PRIVATE KEY (REQUIRED)

--- a/deployments/lilbrotr/config/services/refresher.yaml
+++ b/deployments/lilbrotr/config/services/refresher.yaml
@@ -6,8 +6,8 @@
 # =============================================================================
 
 pool:
-  user: lilbrotr_writer
-  password_env: DB_WRITER_PASSWORD
+  user: lilbrotr_refresher
+  password_env: DB_REFRESHER_PASSWORD
   max_size: 2
 
 metrics:

--- a/deployments/lilbrotr/docker-compose.yaml
+++ b/deployments/lilbrotr/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
       PGDATA: /var/lib/postgresql/data/pgdata
       DB_WRITER_PASSWORD: ${DB_WRITER_PASSWORD}
       DB_READER_PASSWORD: ${DB_READER_PASSWORD}
+      DB_REFRESHER_PASSWORD: ${DB_REFRESHER_PASSWORD}
 
     volumes:
       - ./data/postgres:/var/lib/postgresql/data                # Persistent data
@@ -76,6 +77,7 @@ services:
       DB_ADMIN_PASSWORD: ${DB_ADMIN_PASSWORD}
       DB_WRITER_PASSWORD: ${DB_WRITER_PASSWORD}
       DB_READER_PASSWORD: ${DB_READER_PASSWORD}
+      DB_REFRESHER_PASSWORD: ${DB_REFRESHER_PASSWORD}
 
     entrypoint: ["/custom-entrypoint.sh"]
 
@@ -502,7 +504,7 @@ services:
     restart: unless-stopped
 
     environment:
-      DB_WRITER_PASSWORD: ${DB_WRITER_PASSWORD}
+      DB_REFRESHER_PASSWORD: ${DB_REFRESHER_PASSWORD}
 
     volumes:
       - ./config:/app/config:ro

--- a/deployments/lilbrotr/pgbouncer/entrypoint.sh
+++ b/deployments/lilbrotr/pgbouncer/entrypoint.sh
@@ -1,18 +1,20 @@
 #!/bin/sh
 # Generate PgBouncer userlist from environment variables and start PgBouncer.
-# Userlist includes admin (for pool management) + writer/reader application roles.
+# Userlist includes admin (for pool management) + writer/reader/refresher application roles.
 # Role names are derived from POSTGRES_DB environment variable.
 
 set -eu
 
 WRITER_ROLE="${POSTGRES_DB}_writer"
 READER_ROLE="${POSTGRES_DB}_reader"
+REFRESHER_ROLE="${POSTGRES_DB}_refresher"
 
 mkdir -p /tmp/pgbouncer
 cat > /tmp/pgbouncer/userlist.txt <<EOF
 "admin" "${DB_ADMIN_PASSWORD}"
 "${WRITER_ROLE}" "${DB_WRITER_PASSWORD}"
 "${READER_ROLE}" "${DB_READER_PASSWORD}"
+"${REFRESHER_ROLE}" "${DB_REFRESHER_PASSWORD}"
 EOF
 chmod 600 /tmp/pgbouncer/userlist.txt
 

--- a/deployments/lilbrotr/postgres/init/06_materialized_views.sql
+++ b/deployments/lilbrotr/postgres/init/06_materialized_views.sql
@@ -162,9 +162,9 @@ LEFT JOIN event_agg AS ea ON r.url = ea.relay_url
 -- LATERAL join: compute average RTT from the 10 most recent measurements
 LEFT JOIN LATERAL (
     SELECT
-        ROUND(AVG((m.data ->> 'rtt_open')::INTEGER)::NUMERIC, 2) AS avg_rtt_open,
-        ROUND(AVG((m.data ->> 'rtt_read')::INTEGER)::NUMERIC, 2) AS avg_rtt_read,
-        ROUND(AVG((m.data ->> 'rtt_write')::INTEGER)::NUMERIC, 2) AS avg_rtt_write
+        ROUND(AVG((m.data -> 'data' ->> 'rtt_open')::INTEGER)::NUMERIC, 2) AS avg_rtt_open,
+        ROUND(AVG((m.data -> 'data' ->> 'rtt_read')::INTEGER)::NUMERIC, 2) AS avg_rtt_read,
+        ROUND(AVG((m.data -> 'data' ->> 'rtt_write')::INTEGER)::NUMERIC, 2) AS avg_rtt_write
     FROM (
         SELECT
             rm.metadata_id,
@@ -180,9 +180,9 @@ LEFT JOIN LATERAL (
 -- LATERAL join: latest NIP-11 relay info
 LEFT JOIN LATERAL (
     SELECT
-        m.data ->> 'name' AS name,
-        m.data ->> 'software' AS software,
-        m.data ->> 'version' AS version
+        m.data -> 'data' ->> 'name' AS name,
+        m.data -> 'data' ->> 'software' AS software,
+        m.data -> 'data' ->> 'version' AS version
     FROM relay_metadata AS rm
     INNER JOIN metadata AS m ON rm.metadata_id = m.id AND rm.metadata_type = m.metadata_type
     WHERE rm.relay_url = r.url AND rm.metadata_type = 'nip11_info'
@@ -337,13 +337,13 @@ COMMENT ON MATERIALIZED VIEW network_stats IS
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS relay_software_counts AS
 SELECT
-    data ->> 'software' AS software,
-    COALESCE(data ->> 'version', 'unknown') AS version,
+    data -> 'data' ->> 'software' AS software,
+    COALESCE(data -> 'data' ->> 'version', 'unknown') AS version,
     COUNT(*) AS relay_count
 FROM relay_metadata_latest
 WHERE metadata_type = 'nip11_info'
-    AND data ->> 'software' IS NOT NULL
-GROUP BY data ->> 'software', COALESCE(data ->> 'version', 'unknown')
+    AND data -> 'data' ->> 'software' IS NOT NULL
+GROUP BY data -> 'data' ->> 'software', COALESCE(data -> 'data' ->> 'version', 'unknown')
 ORDER BY relay_count DESC;
 
 COMMENT ON MATERIALIZED VIEW relay_software_counts IS
@@ -364,10 +364,10 @@ SELECT
     nip_text::INTEGER AS nip,
     COUNT(*) AS relay_count
 FROM relay_metadata_latest
-CROSS JOIN LATERAL jsonb_array_elements_text(data -> 'supported_nips') AS nip_text
+CROSS JOIN LATERAL jsonb_array_elements_text(data -> 'data' -> 'supported_nips') AS nip_text
 WHERE metadata_type = 'nip11_info'
-    AND data ? 'supported_nips'
-    AND jsonb_typeof(data -> 'supported_nips') = 'array'
+    AND data -> 'data' ? 'supported_nips'
+    AND jsonb_typeof(data -> 'data' -> 'supported_nips') = 'array'
     AND nip_text ~ '^\d+$'
 GROUP BY nip_text::INTEGER
 ORDER BY relay_count DESC;

--- a/tests/integration/bigbrotr/test_materialized_views.py
+++ b/tests/integration/bigbrotr/test_materialized_views.py
@@ -53,9 +53,15 @@ async def _insert_nip11_metadata(
     data: dict,
     generated_at: int = 1700000001,
 ) -> None:
-    """Insert NIP-11 info metadata for a relay."""
+    """Insert NIP-11 info metadata for a relay.
+
+    Wraps ``data`` in the production envelope structure produced by
+    ``Nip11InfoMetadata.to_dict()`` so that materialized views using
+    ``data -> 'data' ->> 'field'`` paths resolve correctly.
+    """
     relay = Relay(relay_url, discovered_at=1700000000)
-    metadata = Metadata(type=MetadataType.NIP11_INFO, data=data)
+    envelope = {"data": data, "logs": {"success": True}}
+    metadata = Metadata(type=MetadataType.NIP11_INFO, data=envelope)
     rm = RelayMetadata(relay=relay, metadata=metadata, generated_at=generated_at)
     await brotr.insert_relay_metadata([rm], cascade=True)
 

--- a/tools/templates/sql/base/06_materialized_views.sql.j2
+++ b/tools/templates/sql/base/06_materialized_views.sql.j2
@@ -167,9 +167,9 @@ LEFT JOIN event_agg AS ea ON r.url = ea.relay_url
 -- LATERAL join: compute average RTT from the 10 most recent measurements
 LEFT JOIN LATERAL (
     SELECT
-        ROUND(AVG((m.data ->> 'rtt_open')::INTEGER)::NUMERIC, 2) AS avg_rtt_open,
-        ROUND(AVG((m.data ->> 'rtt_read')::INTEGER)::NUMERIC, 2) AS avg_rtt_read,
-        ROUND(AVG((m.data ->> 'rtt_write')::INTEGER)::NUMERIC, 2) AS avg_rtt_write
+        ROUND(AVG((m.data -> 'data' ->> 'rtt_open')::INTEGER)::NUMERIC, 2) AS avg_rtt_open,
+        ROUND(AVG((m.data -> 'data' ->> 'rtt_read')::INTEGER)::NUMERIC, 2) AS avg_rtt_read,
+        ROUND(AVG((m.data -> 'data' ->> 'rtt_write')::INTEGER)::NUMERIC, 2) AS avg_rtt_write
     FROM (
         SELECT
             rm.metadata_id,
@@ -185,9 +185,9 @@ LEFT JOIN LATERAL (
 -- LATERAL join: latest NIP-11 relay info
 LEFT JOIN LATERAL (
     SELECT
-        m.data ->> 'name' AS name,
-        m.data ->> 'software' AS software,
-        m.data ->> 'version' AS version
+        m.data -> 'data' ->> 'name' AS name,
+        m.data -> 'data' ->> 'software' AS software,
+        m.data -> 'data' ->> 'version' AS version
     FROM relay_metadata AS rm
     INNER JOIN metadata AS m ON rm.metadata_id = m.id AND rm.metadata_type = m.metadata_type
     WHERE rm.relay_url = r.url AND rm.metadata_type = 'nip11_info'
@@ -342,13 +342,13 @@ COMMENT ON MATERIALIZED VIEW network_stats IS
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS relay_software_counts AS
 SELECT
-    data ->> 'software' AS software,
-    COALESCE(data ->> 'version', 'unknown') AS version,
+    data -> 'data' ->> 'software' AS software,
+    COALESCE(data -> 'data' ->> 'version', 'unknown') AS version,
     COUNT(*) AS relay_count
 FROM relay_metadata_latest
 WHERE metadata_type = 'nip11_info'
-    AND data ->> 'software' IS NOT NULL
-GROUP BY data ->> 'software', COALESCE(data ->> 'version', 'unknown')
+    AND data -> 'data' ->> 'software' IS NOT NULL
+GROUP BY data -> 'data' ->> 'software', COALESCE(data -> 'data' ->> 'version', 'unknown')
 ORDER BY relay_count DESC;
 
 COMMENT ON MATERIALIZED VIEW relay_software_counts IS
@@ -369,10 +369,10 @@ SELECT
     nip_text::INTEGER AS nip,
     COUNT(*) AS relay_count
 FROM relay_metadata_latest
-CROSS JOIN LATERAL jsonb_array_elements_text(data -> 'supported_nips') AS nip_text
+CROSS JOIN LATERAL jsonb_array_elements_text(data -> 'data' -> 'supported_nips') AS nip_text
 WHERE metadata_type = 'nip11_info'
-    AND data ? 'supported_nips'
-    AND jsonb_typeof(data -> 'supported_nips') = 'array'
+    AND data -> 'data' ? 'supported_nips'
+    AND jsonb_typeof(data -> 'data' -> 'supported_nips') = 'array'
     AND nip_text ~ '^\d+$'
 GROUP BY nip_text::INTEGER
 ORDER BY relay_count DESC;


### PR DESCRIPTION
## Summary

- **Fix 12 JSONB path errors** in materialized views (`relay_stats`, `relay_software_counts`, `supported_nip_counts`) that referenced top-level keys instead of the nested `data` envelope, producing NULL columns
- **Create dedicated `refresher` database role** with least-privilege access (SELECT + matview ownership only), replacing the writer role previously used by the Refresher service
- **Wire the new role** through PGBouncer, Docker Compose, and service config for both `bigbrotr` and `lilbrotr` deployments

## Details

### JSONB path fix (#320)

Metadata is stored with a two-level envelope: `{"data": {...}, "logs": {...}}`. Three materialized views were using `m.data ->> 'field'` instead of the correct `m.data -> 'data' ->> 'field'`, causing all derived columns (RTT values, relay name/software/version, NIP counts) to be NULL.

### Refresher role (#321, #322)

The Refresher service only needs to run `REFRESH MATERIALIZED VIEW CONCURRENTLY` — it never performs INSERT/UPDATE/DELETE. Previously it connected as the writer role, which violates least-privilege. The new `refresher` role has:
- `SELECT` on all tables (required by `CONCURRENTLY`)
- `OWNER` on all 11 materialized views (required to execute refresh)
- No DML privileges

### Files changed (both deployments)

| File | Change |
|------|--------|
| `postgres/init/06_materialized_views.sql` | Fix 12 JSONB path expressions |
| `postgres/init/01_roles.sh` | Create refresher role idempotently |
| `postgres/init/98_grants.sh` | Grant SELECT + matview ownership to refresher |
| `docker-compose.yaml` | Wire `DB_REFRESHER_PASSWORD` to postgres, pgbouncer, refresher |
| `pgbouncer/entrypoint.sh` | Add refresher to connection pool userlist |
| `config/services/refresher.yaml` | Switch `pool.user` and `pool.password_env` |
| `.env.example` | Document `DB_REFRESHER_PASSWORD` |
| `.secrets.baseline` | Update hashes for changed password_env values |

## Test plan

- [ ] Verify `make ci` passes (ruff, mypy, 2442 unit tests — confirmed locally)
- [ ] Deploy to staging with fresh DB init — verify refresher role is created
- [ ] Verify `REFRESH MATERIALIZED VIEW CONCURRENTLY` succeeds for all 11 views
- [ ] Verify materialized view columns now contain actual data (not NULL)
- [ ] Verify refresher service cannot INSERT/UPDATE/DELETE on any table

Closes #320, Closes #321, Closes #322