### PR TITLE
fix: harden Catalog discovery against system view exposure

### DIFF
--- a/deployments/bigbrotr/config/services/api.yaml
+++ b/deployments/bigbrotr/config/services/api.yaml
@@ -15,6 +15,10 @@ interval: 60.0
 tables:
   service_state:
     enabled: false
+  pg_stat_statements:
+    enabled: false
+  pg_stat_statements_info:
+    enabled: false
 
 metrics:
   enabled: true

--- a/deployments/bigbrotr/config/services/dvm.yaml
+++ b/deployments/bigbrotr/config/services/dvm.yaml
@@ -19,6 +19,10 @@ relays:
 tables:
   service_state:
     enabled: false
+  pg_stat_statements:
+    enabled: false
+  pg_stat_statements_info:
+    enabled: false
 
 metrics:
   enabled: true

--- a/deployments/lilbrotr/config/services/api.yaml
+++ b/deployments/lilbrotr/config/services/api.yaml
@@ -15,6 +15,10 @@ interval: 60.0
 tables:
   service_state:
     enabled: false
+  pg_stat_statements:
+    enabled: false
+  pg_stat_statements_info:
+    enabled: false
 
 metrics:
   enabled: true

--- a/deployments/lilbrotr/config/services/dvm.yaml
+++ b/deployments/lilbrotr/config/services/dvm.yaml
@@ -19,6 +19,10 @@ relays:
 tables:
   service_state:
     enabled: false
+  pg_stat_statements:
+    enabled: false
+  pg_stat_statements_info:
+    enabled: false
 
 metrics:
   enabled: true


### PR DESCRIPTION
## Summary

- **Disable `pg_stat_statements`** and `pg_stat_statements_info` in API and DVM service configs for both deployments — these extension-provided views contain full SQL query text and could leak internal schema details
- **Add `pg_` prefix filter** to `Catalog.discover()` — automatically excludes all PostgreSQL system objects regardless of per-service config
- **Add identifier validation** — discovered names must match `^[a-z_][a-z0-9_]*$`, consistent with `Brotr._VALID_PROCEDURE_NAME`

## Details

### Config changes (#324)

Added to all 4 API/DVM configs (bigbrotr + lilbrotr):
```yaml
tables:
  pg_stat_statements:
    enabled: false
  pg_stat_statements_info:
    enabled: false
```

### Catalog hardening (#325)

`Catalog._filter_names()` runs after each discovery query and before names are used:
1. Skips names starting with `pg_` (defense-in-depth against system view exposure)
2. Validates against `^[a-z_][a-z0-9_]*$` regex (prevents invalid identifiers from entering query builder)

### Tests

7 new tests in `test_catalog.py`:
- `TestFilterNames`: 5 tests for the filtering logic (pg_ prefix, invalid identifiers, valid names, empty set, all-filtered)
- `TestCatalogDiscover::test_discover_filters_pg_prefix`: end-to-end test verifying `pg_stat_statements` is excluded from discovery

## Test plan

- [x] `make ci` passes locally (ruff, mypy, 2469 unit tests)
- [ ] Verify API service does not expose `pg_stat_statements` endpoint after deploy
- [ ] Verify DVM service does not return `pg_stat_statements` data in query results

Closes #324, Closes #325