### PR TITLE
refactor: harden code quality across services and core

### DIFF
--- a/src/bigbrotr/core/brotr.py
+++ b/src/bigbrotr/core/brotr.py
@@ -629,15 +629,11 @@ class Brotr:
         self._validate_batch_size(records, "insert_metadata")
 
         params = [metadata.to_db_params() for metadata in records]
-        ids = [p.id for p in params]
-        types = [p.type for p in params]
-        values = [p.data for p in params]
+        columns = self._transpose_to_columns(params)
 
         inserted: int = await self._call_procedure(
             "metadata_insert",
-            ids,
-            types,
-            values,
+            *columns,
             fetch_result=True,
             timeout=self._config.timeouts.batch,
         )

--- a/src/bigbrotr/nips/nip66/geo.py
+++ b/src/bigbrotr/nips/nip66/geo.py
@@ -231,7 +231,7 @@ class Nip66GeoMetadata(BaseNipMetadata):
                     logger.debug("geo_no_data relay=%s", relay.url)
             except (geoip2.errors.GeoIP2Error, ValueError) as e:
                 logs["reason"] = str(e) or type(e).__name__
-                logger.debug("geo_lookup_failed relay=%s error=%s", relay.url, str(e))
+                logger.debug("geo_lookup_failed relay=%s error=%s", relay.url, logs["reason"])
         else:
             logs["reason"] = "could not resolve hostname to IP"
             logger.debug("geo_no_ip relay=%s", relay.url)

--- a/src/bigbrotr/nips/nip66/http.py
+++ b/src/bigbrotr/nips/nip66/http.py
@@ -186,7 +186,7 @@ class Nip66HttpMetadata(BaseNipMetadata):
                 logger.debug("http_no_data relay=%s", relay.url)
         except (OSError, TimeoutError, aiohttp.ClientError) as e:
             logs["reason"] = str(e) or type(e).__name__
-            logger.debug("http_error relay=%s error=%s", relay.url, str(e))
+            logger.debug("http_error relay=%s error=%s", relay.url, logs["reason"])
 
         return cls(
             data=Nip66HttpData.model_validate(Nip66HttpData.parse(data)),

--- a/src/bigbrotr/nips/nip66/rtt.py
+++ b/src/bigbrotr/nips/nip66/rtt.py
@@ -36,7 +36,6 @@ See Also:
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 from datetime import timedelta
 from time import perf_counter
@@ -367,6 +366,7 @@ class Nip66RttMetadata(BaseNipMetadata):
     @staticmethod
     async def _cleanup(client: Client) -> None:
         """Disconnect the client, suppressing any errors."""
-        # nostr-sdk Rust FFI can raise arbitrary exception types during disconnect.
-        with contextlib.suppress(Exception):
+        try:
             await client.disconnect()
+        except Exception as e:
+            logger.debug("client_disconnect_error error=%s", e)

--- a/src/bigbrotr/nips/nip66/ssl.py
+++ b/src/bigbrotr/nips/nip66/ssl.py
@@ -277,7 +277,7 @@ class Nip66SslMetadata(BaseNipMetadata):
                 logger.debug("ssl_no_data relay=%s", relay.url)
         except OSError as e:
             logs["reason"] = str(e) or type(e).__name__
-            logger.debug("ssl_error relay=%s error=%s", relay.url, str(e))
+            logger.debug("ssl_error relay=%s error=%s", relay.url, logs["reason"])
 
         return cls(
             data=Nip66SslData.model_validate(Nip66SslData.parse(data)),

--- a/src/bigbrotr/services/common/queries.py
+++ b/src/bigbrotr/services/common/queries.py
@@ -337,7 +337,7 @@ async def scan_event(
     """
     rows = await brotr.fetch(
         """
-        SELECT *
+        SELECT id, pubkey, created_at, kind, tags, tagvalues, content, sig
         FROM event
         WHERE ($1::bigint IS NULL OR (created_at, id) > ($1::bigint, $2::bytea))
         ORDER BY created_at ASC, id ASC
@@ -630,6 +630,8 @@ async def delete_exhausted_candidates(
         [cleanup_service_state][bigbrotr.services.common.queries.cleanup_service_state]:
             Companion cleanup that removes stale candidates and state records.
     """
+    # Direct DELETE (not via stored procedure) — cleanup query, already
+    # centralised and parameterised; a procedure adds no benefit here.
     count: int = await brotr.fetchval(
         """
         WITH deleted AS (
@@ -683,6 +685,8 @@ async def cleanup_service_state(
             f"got {state_type.value!r}"
         )
 
+    # Direct DELETE (not via stored procedure) — cleanup query, already
+    # centralised and parameterised; a procedure adds no benefit here.
     if state_type in _EXISTS_STALE_TYPES:
         # CANDIDATE: stale when relay exists (already promoted)
         query = """

--- a/src/bigbrotr/services/dvm/service.py
+++ b/src/bigbrotr/services/dvm/service.py
@@ -148,8 +148,10 @@ class Dvm(BaseService[DvmConfig]):
         _exc_tb: TracebackType | None,
     ) -> None:
         if self._client is not None:
-            with contextlib.suppress(Exception):
+            try:
                 await self._client.shutdown()
+            except Exception as e:
+                self._logger.debug("client_shutdown_error", error=str(e))
             self._client = None
             self._logger.info("client_disconnected")
         await super().__aexit__(_exc_type, _exc_val, _exc_tb)

--- a/src/bigbrotr/services/monitor/configs.py
+++ b/src/bigbrotr/services/monitor/configs.py
@@ -180,7 +180,9 @@ class PublishingConfig(BaseModel):
         list[Relay],
         BeforeValidator(lambda v: safe_parse(v, Relay)),
     ] = Field(default_factory=list)
-    timeout: float = Field(default=30.0, ge=0.1, description="Broadcast timeout in seconds")
+    timeout: float = Field(
+        default=30.0, ge=0.1, le=300.0, description="Broadcast timeout in seconds"
+    )
 
 
 class DiscoveryConfig(BaseModel):
@@ -192,7 +194,7 @@ class DiscoveryConfig(BaseModel):
     """
 
     enabled: bool = Field(default=True)
-    interval: float = Field(default=3600.0, ge=60.0)
+    interval: float = Field(default=3600.0, ge=60.0, le=604800.0)
     include: MetadataFlags = Field(default_factory=MetadataFlags)
     relays: Annotated[
         list[Relay] | None,
@@ -209,7 +211,7 @@ class AnnouncementConfig(BaseModel):
     """
 
     enabled: bool = Field(default=True)
-    interval: float = Field(default=86_400.0, ge=60.0)
+    interval: float = Field(default=86_400.0, ge=60.0, le=604800.0)
     relays: Annotated[
         list[Relay] | None,
         BeforeValidator(lambda v: safe_parse(v, Relay) if v is not None else None),
@@ -225,7 +227,7 @@ class ProfileConfig(BaseModel):
     """
 
     enabled: bool = Field(default=False)
-    interval: float = Field(default=86_400.0, ge=60.0)
+    interval: float = Field(default=86_400.0, ge=60.0, le=604800.0)
     relays: Annotated[
         list[Relay] | None,
         BeforeValidator(lambda v: safe_parse(v, Relay) if v is not None else None),

--- a/src/bigbrotr/services/refresher/configs.py
+++ b/src/bigbrotr/services/refresher/configs.py
@@ -10,10 +10,14 @@ See Also:
 
 from __future__ import annotations
 
+import re
+
 from pydantic import BaseModel, Field, field_validator
 
 from bigbrotr.core.base_service import BaseServiceConfig
 
+
+_VIEW_NAME_PATTERN = re.compile(r"^[a-z_][a-z0-9_]*$")
 
 #: Default view refresh order respecting 3-level dependency chain:
 #: Level 1 — relay_metadata_latest (base dependency)
@@ -52,6 +56,11 @@ class RefreshConfig(BaseModel):
     def views_not_empty(cls, v: list[str]) -> list[str]:
         if not v:
             raise ValueError("views list must not be empty")
+        invalid = [name for name in v if not _VIEW_NAME_PATTERN.match(name)]
+        if invalid:
+            raise ValueError(
+                f"invalid view names (must match [a-z_][a-z0-9_]*): {', '.join(invalid)}"
+            )
         return v
 
 

--- a/src/bigbrotr/services/synchronizer/service.py
+++ b/src/bigbrotr/services/synchronizer/service.py
@@ -245,8 +245,8 @@ class Synchronizer(NetworkSemaphoresMixin, BaseService[SynchronizerConfig]):
                     relay_url=s.state_key,
                     seen_at=int(s.state_value["last_synced_at"]),
                 )
-            except (ValueError, TypeError):
-                self._logger.warning("invalid_cursor_data", relay=s.state_key)
+            except (ValueError, TypeError) as e:
+                self._logger.warning("invalid_cursor_data", relay=s.state_key, error=str(e))
         return cursors
 
     def _merge_overrides(self, relays: list[Relay]) -> list[Relay]:

--- a/src/bigbrotr/utils/protocol.py
+++ b/src/bigbrotr/utils/protocol.py
@@ -375,8 +375,10 @@ async def broadcast_events(
         except (OSError, TimeoutError) as e:
             logger.warning("broadcast_send_failed relay=%s error=%s", relay.url, e)
         finally:
-            with contextlib.suppress(Exception):
+            try:
                 await client.shutdown()
+            except Exception as e:
+                logger.debug("client_shutdown_error relay=%s error=%s", relay.url, e)
 
     return success
 
@@ -450,6 +452,7 @@ async def is_nostr_relay(
 
         finally:
             if client is not None:
-                # nostr-sdk Rust FFI can raise arbitrary exception types during disconnect.
-                with contextlib.suppress(Exception):
+                try:
                     await asyncio.wait_for(client.disconnect(), timeout=timeout)
+                except Exception as e:
+                    logger.debug("client_disconnect_error error=%s", e)

--- a/src/bigbrotr/utils/transport.py
+++ b/src/bigbrotr/utils/transport.py
@@ -27,7 +27,6 @@ See Also:
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import ssl
 import sys
@@ -186,12 +185,14 @@ class InsecureWebSocketAdapter(WebSocketAdapter):
 
     async def close_connection(self) -> None:
         """Close the WebSocket and session with timeouts to prevent hanging."""
-        # aiohttp/websockets can raise ClientError, ServerDisconnectedError, etc.
-        # during close — broad suppression is intentional for cleanup teardown.
-        with contextlib.suppress(Exception):
+        try:
             await asyncio.wait_for(self._ws.close(), timeout=self._close_timeout)
-        with contextlib.suppress(Exception):
+        except Exception as e:
+            logger.debug("ws_close_error error=%s", e)
+        try:
             await asyncio.wait_for(self._session.close(), timeout=self._close_timeout)
+        except Exception as e:
+            logger.debug("session_close_error error=%s", e)
 
 
 class InsecureWebSocketTransport(CustomWebSocketTransport):

--- a/tests/unit/services/test_monitor_configs.py
+++ b/tests/unit/services/test_monitor_configs.py
@@ -14,10 +14,14 @@ from unittest.mock import patch
 import pytest
 
 from bigbrotr.services.monitor.configs import (
+    AnnouncementConfig,
+    DiscoveryConfig,
     GeoConfig,
     MetadataFlags,
     MonitorConfig,
     ProcessingConfig,
+    ProfileConfig,
+    PublishingConfig,
     RetriesConfig,
     RetryConfig,
 )
@@ -337,3 +341,44 @@ class TestMonitorConfigValidatePublishRequiresCompute:
             ),
         )
         assert config.discovery.enabled is False
+
+
+# ============================================================================
+# Upper bound validation tests
+# ============================================================================
+
+
+class TestPublishingConfig:
+    """Tests for PublishingConfig field constraints."""
+
+    def test_timeout_upper_bound_rejected(self) -> None:
+        """Timeout above 300s is rejected."""
+        with pytest.raises(ValueError):
+            PublishingConfig(timeout=301.0)
+
+
+class TestDiscoveryConfig:
+    """Tests for DiscoveryConfig field constraints."""
+
+    def test_interval_upper_bound_rejected(self) -> None:
+        """Interval above 7 days is rejected."""
+        with pytest.raises(ValueError):
+            DiscoveryConfig(interval=604801.0)
+
+
+class TestAnnouncementConfig:
+    """Tests for AnnouncementConfig field constraints."""
+
+    def test_interval_upper_bound_rejected(self) -> None:
+        """Interval above 7 days is rejected."""
+        with pytest.raises(ValueError):
+            AnnouncementConfig(interval=604801.0)
+
+
+class TestProfileConfig:
+    """Tests for ProfileConfig field constraints."""
+
+    def test_interval_upper_bound_rejected(self) -> None:
+        """Interval above 7 days is rejected."""
+        with pytest.raises(ValueError):
+            ProfileConfig(interval=604801.0)

--- a/tests/unit/services/test_refresher.py
+++ b/tests/unit/services/test_refresher.py
@@ -80,6 +80,16 @@ class TestRefreshConfig:
         with pytest.raises(ValueError, match="views list must not be empty"):
             RefreshConfig(views=[])
 
+    def test_valid_view_names_accepted(self) -> None:
+        """Test valid SQL identifier view names pass validation."""
+        config = RefreshConfig(views=["relay_stats", "event_daily_counts"])
+        assert config.views == ["relay_stats", "event_daily_counts"]
+
+    def test_invalid_view_names_rejected(self) -> None:
+        """Test invalid view names raise validation error."""
+        with pytest.raises(ValueError, match="invalid view names"):
+            RefreshConfig(views=["relay-stats", "INVALID", "DROP TABLE"])
+
     def test_default_views_is_independent_copy(self) -> None:
         """Test each config gets an independent copy of DEFAULT_VIEWS."""
         config1 = RefreshConfig()


### PR DESCRIPTION
## Summary

- **Exception handling**: Replace all `contextlib.suppress(Exception)` with `try/except` + log DEBUG across cleanup paths (dvm, protocol, transport, rtt) for better observability
- **Config validation**: Add regex validation on refresher view names (`^[a-z_][a-z0-9_]*$`), add `le=` upper bounds on 4 monitor config fields (publishing timeout, discovery/announcement/profile intervals)
- **Query hardening**: Replace `SELECT *` with explicit columns in `scan_event`, align `insert_metadata` to `_transpose_to_columns` pattern, wrap DNS `asyncio.to_thread` with `asyncio.wait_for` timeout
- **NIP module consistency**: Standardise `logs["reason"]` assignment (`str(e) or type(e).__name__`) and corresponding log output across all NIP-66 modules (ssl, http, geo, dns)
- **Documentation**: Inline comments on intentional direct DELETE queries in `common/queries.py`

## Files changed (16)

**Production (13):** `brotr.py`, `dns.py`, `geo.py`, `http.py`, `rtt.py`, `ssl.py`, `queries.py`, `dvm/service.py`, `monitor/configs.py`, `refresher/configs.py`, `synchronizer/service.py`, `protocol.py`, `transport.py`

**Tests (3):** `test_dns.py` (+1 test), `test_monitor_configs.py` (+4 tests), `test_refresher.py` (+2 tests)

## Test plan

- [x] `ruff check src/ tests/` — zero errors
- [x] `mypy src/bigbrotr` — zero errors
- [x] `pytest tests/ --ignore=tests/integration/` — 2469 passed
- [x] 7 new unit tests covering added validation and timeout behaviour
- [x] No deployment YAML conflicts (verified bigbrotr + lilbrotr configs within new bounds)