### PR TITLE
fix: resolve ambiguous alias in filter_new_relays query

### DIFF
--- a/src/bigbrotr/services/common/queries.py
+++ b/src/bigbrotr/services/common/queries.py
@@ -195,12 +195,12 @@ async def filter_new_relays(
 
     rows = await brotr.fetch(
         """
-        SELECT url FROM unnest($1::text[]) AS url
-        WHERE NOT EXISTS (SELECT 1 FROM relay r WHERE r.url = url)
+        SELECT t.url FROM unnest($1::text[]) AS t(url)
+        WHERE NOT EXISTS (SELECT 1 FROM relay r WHERE r.url = t.url)
           AND NOT EXISTS (
               SELECT 1 FROM service_state ss
               WHERE ss.service_name = $2 AND ss.state_type = $3
-                AND ss.state_key = url
+                AND ss.state_key = t.url
           )
         """,
         urls,


### PR DESCRIPTION
## Summary
- Fixed SQL alias ambiguity in `filter_new_relays` where `unnest($1::text[]) AS url` was interpreted as a relation alias by PostgreSQL 16, causing subquery comparisons to silently fail
- Changed to explicit column alias `AS t(url)` with qualified `t.url` references
- On a fresh database, `filter_new_relays` was returning 0 rows — seeder could not insert any candidates

## Test plan
- [x] `pytest tests/unit/services/common/test_queries.py` — 50 tests pass
- [x] Verified directly in PostgreSQL: old query returns 0 rows, fixed query returns correct results
- [x] Full deployment test: seeder correctly inserted 6947 candidates after fix