### PR TITLE
feat: make API route prefix configurable

### DIFF
--- a/src/bigbrotr/services/api/service.py
+++ b/src/bigbrotr/services/api/service.py
@@ -180,7 +180,9 @@ class Api(CatalogAccessMixin, BaseService[ApiConfig]):
             return {"status": "ok"}
 
         # Schema endpoints
-        @app.get("/api/v1/schema")
+        prefix = self._config.route_prefix
+
+        @app.get(f"{prefix}/schema")
         async def list_schema() -> JSONResponse:
             tables = [
                 {
@@ -194,7 +196,7 @@ class Api(CatalogAccessMixin, BaseService[ApiConfig]):
             ]
             return JSONResponse({"data": tables})
 
-        @app.get("/api/v1/schema/{table}")
+        @app.get(f"{prefix}/schema/{{table}}")
         async def get_schema(table: str) -> JSONResponse:
             if table not in self._catalog.tables or not self._is_table_enabled(table):
                 return JSONResponse(
@@ -237,7 +239,7 @@ class Api(CatalogAccessMixin, BaseService[ApiConfig]):
         schema = self._catalog.tables[table_name]
         pk_cols = schema.primary_key
 
-        @app.get(f"/api/v1/{table_name}")
+        @app.get(f"{self._config.route_prefix}/{table_name}")
         async def list_rows(request: Request) -> JSONResponse:
             params = dict(request.query_params)
             try:
@@ -289,7 +291,7 @@ class Api(CatalogAccessMixin, BaseService[ApiConfig]):
             else:
                 pk_path = "/".join(f"{{{pk}}}" for pk in pk_cols)
 
-            @app.get(f"/api/v1/{table_name}/{pk_path}")
+            @app.get(f"{self._config.route_prefix}/{table_name}/{pk_path}")
             async def get_row(request: Request) -> JSONResponse:
                 pk_values = {col: request.path_params[col] for col in pk_cols}
                 try:

--- a/tests/unit/services/api/test_configs.py
+++ b/tests/unit/services/api/test_configs.py
@@ -60,3 +60,26 @@ class TestApiConfig:
         """Test that empty host string is rejected."""
         with pytest.raises(ValueError):
             ApiConfig(host="")
+
+
+class TestApiConfigRoutePrefix:
+    """Tests for route_prefix field validation and normalization."""
+
+    def test_default(self) -> None:
+        assert ApiConfig().route_prefix == "/v1"
+
+    def test_custom(self) -> None:
+        assert ApiConfig(route_prefix="/api/v1").route_prefix == "/api/v1"
+
+    def test_trailing_slash_stripped(self) -> None:
+        assert ApiConfig(route_prefix="/v1/").route_prefix == "/v1"
+
+    def test_leading_slash_added(self) -> None:
+        assert ApiConfig(route_prefix="v1").route_prefix == "/v1"
+
+    def test_both_slashes_normalized(self) -> None:
+        assert ApiConfig(route_prefix="api/v2/").route_prefix == "/api/v2"
+
+    def test_slash_only_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"route_prefix must not be empty"):
+            ApiConfig(route_prefix="/")

--- a/tests/unit/services/api/test_service.py
+++ b/tests/unit/services/api/test_service.py
@@ -14,11 +14,13 @@ import pytest
 from fastapi.testclient import TestClient
 
 from bigbrotr.models.constants import ServiceName
+from bigbrotr.services.api.configs import ApiConfig
 from bigbrotr.services.api.service import Api
 from bigbrotr.services.common.catalog import (
     CatalogError,
     QueryResult,
 )
+from bigbrotr.services.common.configs import TableConfig
 
 
 # ============================================================================
@@ -52,7 +54,7 @@ class TestApiEndpoints:
         assert resp.json() == {"status": "ok"}
 
     def test_schema_list(self, test_client: TestClient) -> None:
-        resp = test_client.get("/api/v1/schema")
+        resp = test_client.get("/v1/schema")
         assert resp.status_code == 200
         data = resp.json()["data"]
         names = [t["name"] for t in data]
@@ -62,7 +64,7 @@ class TestApiEndpoints:
         assert "service_state" not in names
 
     def test_schema_detail(self, test_client: TestClient) -> None:
-        resp = test_client.get("/api/v1/schema/relay")
+        resp = test_client.get("/v1/schema/relay")
         assert resp.status_code == 200
         data = resp.json()["data"]
         assert data["name"] == "relay"
@@ -71,11 +73,11 @@ class TestApiEndpoints:
         assert data["primary_key"] == ["url"]
 
     def test_schema_detail_disabled_table(self, test_client: TestClient) -> None:
-        resp = test_client.get("/api/v1/schema/service_state")
+        resp = test_client.get("/v1/schema/service_state")
         assert resp.status_code == 404
 
     def test_schema_detail_nonexistent(self, test_client: TestClient) -> None:
-        resp = test_client.get("/api/v1/schema/nonexistent")
+        resp = test_client.get("/v1/schema/nonexistent")
         assert resp.status_code == 404
 
     def test_list_rows(self, test_client: TestClient, api_service: Api) -> None:
@@ -88,7 +90,7 @@ class TestApiEndpoints:
         with patch.object(
             api_service._catalog, "query", new_callable=AsyncMock, return_value=mock_result
         ):
-            resp = test_client.get("/api/v1/relay?limit=10")
+            resp = test_client.get("/v1/relay?limit=10")
 
         assert resp.status_code == 200
         body = resp.json()
@@ -103,7 +105,7 @@ class TestApiEndpoints:
             new_callable=AsyncMock,
             side_effect=CatalogError("Unknown column: bad"),
         ):
-            resp = test_client.get("/api/v1/relay?bad=value")
+            resp = test_client.get("/v1/relay?bad=value")
         assert resp.status_code == 400
 
     def test_get_row_by_pk(self, test_client: TestClient, api_service: Api) -> None:
@@ -114,7 +116,7 @@ class TestApiEndpoints:
             new_callable=AsyncMock,
             return_value=mock_row,
         ):
-            resp = test_client.get("/api/v1/relay/wss://relay.example.com")
+            resp = test_client.get("/v1/relay/wss://relay.example.com")
 
         assert resp.status_code == 200
         assert resp.json()["data"] == mock_row
@@ -126,16 +128,16 @@ class TestApiEndpoints:
             new_callable=AsyncMock,
             return_value=None,
         ):
-            resp = test_client.get("/api/v1/relay/wss://nonexistent")
+            resp = test_client.get("/v1/relay/wss://nonexistent")
         assert resp.status_code == 404
 
     def test_disabled_table_not_routed(self, test_client: TestClient) -> None:
-        resp = test_client.get("/api/v1/service_state")
+        resp = test_client.get("/v1/service_state")
         assert resp.status_code in (404, 405)
 
     def test_view_has_no_pk_route(self, test_client: TestClient) -> None:
         # relay_stats has no PK so no detail route should exist
-        resp = test_client.get("/api/v1/relay_stats/something")
+        resp = test_client.get("/v1/relay_stats/something")
         assert resp.status_code in (404, 405)
 
     def test_table_policy_bypass_rejected(self, test_client: TestClient, api_service: Api) -> None:
@@ -146,17 +148,17 @@ class TestApiEndpoints:
             new_callable=AsyncMock,
             side_effect=CatalogError("Unknown column: _table"),
         ):
-            resp = test_client.get("/api/v1/relay?_table=service_state")
+            resp = test_client.get("/v1/relay?_table=service_state")
         # _table is treated as a filter column (unknown), not as a route override
         assert resp.status_code == 400
 
     def test_invalid_limit_returns_400(self, test_client: TestClient) -> None:
-        resp = test_client.get("/api/v1/relay?limit=not_a_number")
+        resp = test_client.get("/v1/relay?limit=not_a_number")
         assert resp.status_code == 400
         assert "Invalid limit" in resp.json()["error"]
 
     def test_invalid_offset_returns_400(self, test_client: TestClient) -> None:
-        resp = test_client.get("/api/v1/relay?offset=abc")
+        resp = test_client.get("/v1/relay?offset=abc")
         assert resp.status_code == 400
         assert "Invalid limit" in resp.json()["error"]
 
@@ -180,7 +182,7 @@ class TestApiFallbackHandler:
             new_callable=AsyncMock,
             side_effect=RuntimeError("unexpected DB failure"),
         ):
-            resp = test_client.get("/api/v1/relay?limit=10")
+            resp = test_client.get("/v1/relay?limit=10")
 
         assert resp.status_code == 500
         assert resp.json()["error"] == "Internal server error"
@@ -197,7 +199,7 @@ class TestApiFallbackHandler:
             new_callable=AsyncMock,
             side_effect=CatalogError("Invalid filter value"),
         ):
-            resp = test_client.get("/api/v1/relay?discovered_at=>=:abc")
+            resp = test_client.get("/v1/relay?discovered_at=>=:abc")
 
         assert resp.status_code == 400
         assert "Invalid filter value" in resp.json()["error"]
@@ -219,7 +221,7 @@ class TestApiEndpointTimeouts:
 
         api_service._config.request_timeout = 0.01
         with patch.object(api_service._catalog, "query", side_effect=slow_query):
-            resp = test_client.get("/api/v1/relay?limit=10")
+            resp = test_client.get("/v1/relay?limit=10")
         assert resp.status_code == 504
         assert "timeout" in resp.json()["error"].lower()
 
@@ -231,9 +233,35 @@ class TestApiEndpointTimeouts:
 
         api_service._config.request_timeout = 0.01
         with patch.object(api_service._catalog, "get_by_pk", side_effect=slow_pk):
-            resp = test_client.get("/api/v1/relay/wss://example.com")
+            resp = test_client.get("/v1/relay/wss://example.com")
         assert resp.status_code == 504
         assert "timeout" in resp.json()["error"].lower()
+
+
+# ============================================================================
+# Custom Route Prefix Tests
+# ============================================================================
+
+
+class TestApiCustomPrefix:
+    """Tests for configurable route_prefix."""
+
+    def test_routes_use_custom_prefix(self, mock_brotr: object, sample_catalog: object) -> None:
+        config = ApiConfig(
+            interval=60.0,
+            host="127.0.0.1",
+            port=9999,
+            route_prefix="/api/v2",
+            tables={"relay": TableConfig(enabled=True)},
+        )
+        service = Api(brotr=mock_brotr, config=config)  # type: ignore[arg-type]
+        service._catalog = sample_catalog  # type: ignore[assignment]
+        client = TestClient(service._build_app())
+
+        assert client.get("/api/v2/schema").status_code == 200
+        assert client.get("/api/v2/relay").status_code == 200
+        # Default prefix must not respond
+        assert client.get("/v1/schema").status_code in (404, 405)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Add `route_prefix` field to `ApiConfig` with default `/v1` and input normalization (leading slash, strip trailing slash)
- Replace hardcoded `/api/v1/` prefix in all 4 API routes with the configurable value
- Add validation tests for the new field and an integration test with a custom prefix

## Test plan

- [x] All 2513 unit tests pass
- [x] ruff, mypy clean
- [x] Test with default prefix (`/v1`)
- [x] Test with custom prefix (`/api/v2`)
- [x] Test normalization edge cases (trailing slash, missing leading slash, slash-only rejected)