### PR TITLE
refactor(finder): align with synchronizer patterns

### DIFF
--- a/docs/user-guide/architecture.md
+++ b/docs/user-guide/architecture.md
@@ -454,10 +454,10 @@ Each service also has its own `queries.py` module with domain-specific queries:
 
 | Function | Purpose |
 |----------|---------|
-| `fetch_event_relay_cursors(brotr)` | LEFT JOIN relay with service_state for cursor positions |
+| `fetch_cursors_to_find(brotr)` | LEFT JOIN relay with service_state for cursor positions, ordered by (timestamp, id) |
 | `scan_event_relay(brotr, cursor, limit)` | Cursor-paginated event scan with `(seen_at, event_id)` tie-breaking |
-| `load_api_checkpoints(brotr, urls)` | Load per-source timestamps from CHECKPOINT records |
-| `save_api_checkpoints(brotr, checkpoints)` | Persist per-source timestamps as CHECKPOINT records |
+| `fetch_api_checkpoints(brotr, urls)` | Fetch per-source timestamps from CHECKPOINT records |
+| `upsert_api_checkpoints(brotr, checkpoints)` | Persist per-source timestamps as CHECKPOINT records |
 | `save_event_relay_cursor(brotr, cursor)` | Persist scan position (no-op if cursor empty) |
 | `delete_stale_cursors(brotr)` | Remove CURSOR records for deleted relays |
 | `delete_stale_api_checkpoints(brotr, active_urls)` | Remove CHECKPOINT records for removed API sources |

--- a/src/bigbrotr/services/common/types.py
+++ b/src/bigbrotr/services/common/types.py
@@ -43,11 +43,11 @@ class Checkpoint:
     Attributes:
         key: State key identifying the entity (relay URL, API source URL,
             or a named marker like ``"last_announcement"``).
-        timestamp: Unix timestamp of the last processing event.
+        timestamp: Unix timestamp of the last processing event (defaults to 0).
     """
 
     key: str
-    timestamp: int
+    timestamp: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -77,7 +77,7 @@ class PublishCheckpoint(Checkpoint):
     """
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, kw_only=True)
 class CandidateCheckpoint(Checkpoint):
     """Checkpoint for relay validation candidates (Validator).
 

--- a/src/bigbrotr/services/finder/configs.py
+++ b/src/bigbrotr/services/finder/configs.py
@@ -30,8 +30,9 @@ class EventsConfig(BaseModel):
     """
 
     enabled: bool = Field(default=True, description="Enable event scanning")
+    scan_size: int = Field(default=500, ge=10, le=10_000, description="Rows per paginated DB query")
     batch_size: int = Field(
-        default=500, ge=10, le=10_000, description="Events to process per batch"
+        default=500, ge=10, le=10_000, description="Discovered relays to buffer before flushing"
     )
     parallel_relays: int = Field(
         default=50, ge=1, le=200, description="Maximum concurrent relay event scans"

--- a/src/bigbrotr/services/finder/queries.py
+++ b/src/bigbrotr/services/finder/queries.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
 
 from bigbrotr.models.constants import ServiceName
 from bigbrotr.models.service_state import ServiceState, ServiceStateType
+from bigbrotr.services.common.queries import upsert_service_states
 from bigbrotr.services.common.types import ApiCheckpoint, FinderCursor
 
 
@@ -16,21 +16,17 @@ if TYPE_CHECKING:
     from bigbrotr.core.brotr import Brotr
 
 
-logger = logging.getLogger(__name__)
-
-
-async def fetch_event_relay_cursors(brotr: Brotr) -> list[FinderCursor]:
+async def fetch_cursors_to_find(brotr: Brotr) -> list[FinderCursor]:
     """Fetch all relays with their event-scanning cursor position.
 
     Performs a single ``LEFT JOIN`` between the ``relay`` table and
     ``service_state`` (filtered on ``finder`` / ``cursor``), returning an
     [FinderCursor][bigbrotr.services.common.types.FinderCursor] for
-    every relay.  Relays without a stored cursor get
-    ``timestamp=None, id=None`` (scan from beginning).
+    every relay.  Relays without a stored cursor get default values
+    (``timestamp=0``, scan from beginning).
 
-    Cursor rows with corrupt data (non-integer timestamp, non-hex
-    id) are silently treated as missing and the relay will be
-    rescanned from the beginning.
+    Results are ordered by ``(timestamp, id)`` ascending so that relays
+    with the least scanning progress are processed first.
 
     Args:
         brotr: The [Brotr][bigbrotr.core.brotr.Brotr] database facade.
@@ -38,45 +34,38 @@ async def fetch_event_relay_cursors(brotr: Brotr) -> list[FinderCursor]:
     Returns:
         List of
         [FinderCursor][bigbrotr.services.common.types.FinderCursor],
-        one per relay in the database.
+        one per relay in the database, ordered by ``(timestamp, id)``.
     """
     rows = await brotr.fetch(
         """
-        SELECT r.url,
-               (ss.state_value->>'seen_at') AS seen_at,
-               ss.state_value->>'event_id' AS event_id
+        WITH cursors AS (
+            SELECT state_key,
+                   state_value,
+                   (state_value->>'timestamp')::bigint AS ts,
+                   state_value->>'id' AS cursor_id
+            FROM service_state
+            WHERE service_name = $1
+              AND state_type = $2
+        )
+        SELECT r.url, c.state_value
         FROM relay r
-        LEFT JOIN service_state ss ON
-            ss.service_name = $1
-            AND ss.state_type = $2
-            AND ss.state_key = r.url
-        ORDER BY r.url
+        LEFT JOIN cursors c ON c.state_key = r.url
+        ORDER BY COALESCE(c.ts, 0) ASC,
+                 COALESCE(c.cursor_id, repeat('0', 64)) ASC
         """,
         ServiceName.FINDER,
         ServiceStateType.CURSOR,
     )
-    cursors: list[FinderCursor] = []
+    results: list[FinderCursor] = []
     for row in rows:
-        url = row["url"]
-        seen_at_raw = row["seen_at"]
-        event_id_hex = row["event_id"]
-        if seen_at_raw is not None and event_id_hex is not None:
-            try:
-                event_id = str(event_id_hex)
-                bytes.fromhex(event_id)  # validate hex format
-                cursors.append(
-                    FinderCursor(
-                        key=url,
-                        timestamp=int(seen_at_raw),
-                        id=event_id,
-                    )
-                )
-            except (ValueError, TypeError):
-                logger.warning("invalid_cursor_skipped: %s", url)
-                cursors.append(FinderCursor(key=url))
+        sv = row["state_value"]
+        if sv:
+            results.append(
+                FinderCursor(key=row["url"], timestamp=int(sv["timestamp"]), id=str(sv["id"]))
+            )
         else:
-            cursors.append(FinderCursor(key=url))
-    return cursors
+            results.append(FinderCursor(key=row["url"]))
+    return results
 
 
 async def scan_event_relay(
@@ -107,7 +96,7 @@ async def scan_event_relay(
         FROM event e
         INNER JOIN event_relay er ON e.id = er.event_id
         WHERE er.relay_url = $1
-          AND ($2::bigint = 0 OR (er.seen_at, e.id) > ($2::bigint, decode($3, 'hex')))
+          AND (er.seen_at, e.id) > ($2::bigint, decode($3, 'hex'))
         ORDER BY er.seen_at ASC, e.id ASC
         LIMIT $4
         """,
@@ -119,21 +108,24 @@ async def scan_event_relay(
     return [dict(row) for row in rows]
 
 
-async def load_api_checkpoints(brotr: Brotr, urls: list[str]) -> list[ApiCheckpoint]:
-    """Load per-source API timestamps from CHECKPOINT records.
+async def fetch_api_checkpoints(brotr: Brotr, urls: list[str]) -> list[ApiCheckpoint]:
+    """Fetch per-source API checkpoints, returning one per URL.
 
-    Fetches CHECKPOINT records for the given source URLs and returns them
-    as typed [ApiCheckpoint][bigbrotr.services.common.types.ApiCheckpoint]
-    instances.  Records that cannot be parsed (missing or non-integer
-    ``timestamp``) are silently skipped.
+    Returns an [ApiCheckpoint][bigbrotr.services.common.types.ApiCheckpoint]
+    for every URL in *urls*.  URLs with a stored CHECKPOINT record get
+    their persisted ``timestamp``; URLs without a record get a default
+    checkpoint with ``timestamp=0`` (immediately eligible for refresh).
+
+    Records that cannot be parsed (missing or non-integer ``timestamp``)
+    are treated as missing and receive the default.
 
     Args:
         brotr: The [Brotr][bigbrotr.core.brotr.Brotr] database facade.
-        urls: Source URLs to load checkpoints for.
+        urls: Source URLs to fetch checkpoints for.
 
     Returns:
         List of [ApiCheckpoint][bigbrotr.services.common.types.ApiCheckpoint],
-        one per valid stored record.
+        one per input URL, in the same order.
     """
     if not urls:
         return []
@@ -149,18 +141,18 @@ async def load_api_checkpoints(brotr: Brotr, urls: list[str]) -> list[ApiCheckpo
         ServiceStateType.CHECKPOINT,
         urls,
     )
-    checkpoints: list[ApiCheckpoint] = []
+    stored: dict[str, ApiCheckpoint] = {}
     for r in rows:
         try:
-            checkpoints.append(
-                ApiCheckpoint(key=r["state_key"], timestamp=int(r["state_value"]["timestamp"]))
+            stored[r["state_key"]] = ApiCheckpoint(
+                key=r["state_key"], timestamp=int(r["state_value"]["timestamp"])
             )
         except (KeyError, ValueError, TypeError):
             continue
-    return checkpoints
+    return [stored.get(url, ApiCheckpoint(key=url)) for url in urls]
 
 
-async def save_api_checkpoints(brotr: Brotr, checkpoints: list[ApiCheckpoint]) -> None:
+async def upsert_api_checkpoints(brotr: Brotr, checkpoints: list[ApiCheckpoint]) -> None:
     """Persist per-source API timestamps as CHECKPOINT records.
 
     Args:
@@ -168,20 +160,19 @@ async def save_api_checkpoints(brotr: Brotr, checkpoints: list[ApiCheckpoint]) -
         checkpoints: [ApiCheckpoint][bigbrotr.services.common.types.ApiCheckpoint]
             instances to persist.
     """
-    await brotr.upsert_service_state(
-        [
-            ServiceState(
-                service_name=ServiceName.FINDER,
-                state_type=ServiceStateType.CHECKPOINT,
-                state_key=cp.key,
-                state_value={"timestamp": cp.timestamp},
-            )
-            for cp in checkpoints
-        ]
-    )
+    records = [
+        ServiceState(
+            service_name=ServiceName.FINDER,
+            state_type=ServiceStateType.CHECKPOINT,
+            state_key=cp.key,
+            state_value={"timestamp": cp.timestamp},
+        )
+        for cp in checkpoints
+    ]
+    await upsert_service_states(brotr, records)
 
 
-async def save_event_relay_cursors(brotr: Brotr, cursors: Iterable[FinderCursor]) -> None:
+async def upsert_finder_cursors(brotr: Brotr, cursors: Iterable[FinderCursor]) -> None:
     """Persist multiple scan cursor positions in a single batch upsert.
 
     Cursors at default position (timestamp=0) are silently skipped.
@@ -197,15 +188,14 @@ async def save_event_relay_cursors(brotr: Brotr, cursors: Iterable[FinderCursor]
             state_type=ServiceStateType.CURSOR,
             state_key=cursor.key,
             state_value={
-                "seen_at": cursor.timestamp,
-                "event_id": cursor.id,
+                "timestamp": cursor.timestamp,
+                "id": cursor.id,
             },
         )
         for cursor in cursors
         if cursor.timestamp > 0
     ]
-    if states:
-        await brotr.upsert_service_state(states)
+    await upsert_service_states(brotr, states)
 
 
 async def delete_stale_cursors(brotr: Brotr) -> int:

--- a/src/bigbrotr/services/finder/service.py
+++ b/src/bigbrotr/services/finder/service.py
@@ -22,7 +22,7 @@ Note:
     [Synchronizer][bigbrotr.services.synchronizer.Synchronizer] are
     eventually processed. Cursors are stored as
     [ServiceState][bigbrotr.models.service_state.ServiceState] records
-    with ``state_type='cursor'`` and a composite ``(seen_at, event_id)``
+    with ``state_type='cursor'`` and a composite ``(timestamp, id)``
     cursor in ``state_value`` for deterministic resumption.
 
 See Also:
@@ -58,30 +58,27 @@ import time
 from typing import TYPE_CHECKING, ClassVar
 
 import aiohttp
-import asyncpg
 
 from bigbrotr.core.base_service import BaseService
 from bigbrotr.models.constants import ServiceName
 from bigbrotr.services.common.mixins import ConcurrentStreamMixin
 from bigbrotr.services.common.queries import insert_relays_as_candidates
 from bigbrotr.services.common.types import ApiCheckpoint, FinderCursor
-from bigbrotr.utils.http import read_bounded_json
 
 from .configs import ApiSourceConfig, FinderConfig
 from .queries import (
     delete_stale_api_checkpoints,
     delete_stale_cursors,
-    fetch_event_relay_cursors,
-    load_api_checkpoints,
-    save_api_checkpoints,
-    save_event_relay_cursors,
-    scan_event_relay,
+    fetch_api_checkpoints,
+    fetch_cursors_to_find,
+    upsert_api_checkpoints,
+    upsert_finder_cursors,
 )
-from .utils import extract_relays_from_response, extract_relays_from_tagvalues
+from .utils import extract_relays_from_tagvalues, fetch_api, stream_event_relays
 
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, AsyncIterator
+    from collections.abc import AsyncGenerator
 
     from bigbrotr.core.brotr import Brotr
     from bigbrotr.models import Relay
@@ -147,10 +144,9 @@ class Finder(ConcurrentStreamMixin, BaseService[FinderConfig]):
     async def find_from_api(self) -> int:
         """Discover relay URLs from configured external API endpoints.
 
-        Loads per-source timestamps from individual checkpoint records
-        (one per API source URL), skips sources whose ``interval`` has
-        not elapsed, fetches the rest sequentially, deduplicates across
-        sources, and inserts discovered URLs as validation candidates.
+        Delegates fetching to ``_find_from_api_worker``, which iterates
+        all enabled sources sequentially. The parent deduplicates, saves
+        updated checkpoints, and inserts discovered URLs as candidates.
 
         Returns:
             Number of relay URLs inserted as candidates.
@@ -158,99 +154,87 @@ class Finder(ConcurrentStreamMixin, BaseService[FinderConfig]):
         if not self._config.api.enabled:
             return 0
 
-        source_urls = [s.url for s in self._config.api.sources]
-        loaded = await load_api_checkpoints(self._brotr, source_urls)
-        api_state = {cp.key: cp for cp in loaded}
-        now = int(time.time())
+        enabled = [s for s in self._config.api.sources if s.enabled]
 
         seen: set[str] = set()
-        all_relays: list[Relay] = []
-        updated: list[ApiCheckpoint] = []
+        buffer: list[Relay] = []
+        pending_checkpoints: list[ApiCheckpoint] = []
+        sources_fetched = 0
 
-        async with aiohttp.ClientSession() as session:
-            async for source, relays in self._iter_api_relays(session, api_state, now):
-                for relay in relays:
-                    if relay.url not in seen:
-                        seen.add(relay.url)
-                        all_relays.append(relay)
-                updated.append(ApiCheckpoint(key=source.url, timestamp=int(time.time())))
+        self.set_gauge("total_sources", len(enabled))
+        self.set_gauge("sources_fetched", sources_fetched)
+        self.set_gauge("relays_seen", len(seen))
 
-        if updated:
-            await save_api_checkpoints(self._brotr, updated)
+        self._logger.info("api_started", source_count=len(enabled))
 
-        found = await insert_relays_as_candidates(self._brotr, all_relays)
+        async for relays, checkpoint in self._find_from_api_worker(enabled):
+            for relay in relays:
+                if relay.url not in seen:
+                    seen.add(relay.url)
+                    buffer.append(relay)
+            pending_checkpoints.append(checkpoint)
+            sources_fetched += 1
+            self.set_gauge("sources_fetched", sources_fetched)
+            self.set_gauge("relays_seen", len(seen))
 
-        self.set_gauge("api_candidates", found)
-        self.inc_counter("total_api_candidates", found)
-        self._logger.info("apis_completed", found=found, collected=len(all_relays))
+        if pending_checkpoints:
+            await upsert_api_checkpoints(self._brotr, pending_checkpoints)
+
+        found = await insert_relays_as_candidates(self._brotr, buffer)
+
+        self._logger.info("api_completed", found=found, collected=len(buffer))
         return found
 
-    async def _iter_api_relays(
+    async def _find_from_api_worker(
         self,
-        session: aiohttp.ClientSession,
-        api_state: dict[str, ApiCheckpoint],
-        now: int,
-    ) -> AsyncIterator[tuple[ApiSourceConfig, list[Relay]]]:
-        """Yield (source, relays) for each enabled API source that is due for refresh."""
-        enabled = [s for s in self._config.api.sources if s.enabled]
-        for i, source in enumerate(enabled):
-            if not self.is_running:
-                return
+        sources: list[ApiSourceConfig],
+    ) -> AsyncGenerator[tuple[list[Relay], ApiCheckpoint], None]:
+        """Iterate all enabled API sources sequentially.
 
-            checkpoint = api_state.get(source.url)
-            last_checked = checkpoint.timestamp if checkpoint else 0
-            cooldown = self._config.api.cooldown
-            if now - last_checked < cooldown:
-                self._logger.debug(
-                    "api_skipped",
-                    url=source.url,
-                    seconds_left=cooldown - (now - last_checked),
-                )
-                continue
-
-            try:
-                relays = await self._fetch_single_api(session, source)
-                self._logger.debug("api_fetched", url=source.url, count=len(relays))
-                yield source, relays
-            except (TimeoutError, OSError, aiohttp.ClientError, ValueError) as e:
-                self._logger.warning(
-                    "api_fetch_failed",
-                    error=str(e),
-                    error_type=type(e).__name__,
-                    url=source.url,
-                )
-
-            if (
-                self._config.api.request_delay > 0
-                and i < len(enabled) - 1
-                and await self.wait(self._config.api.request_delay)
-            ):
-                return
-
-    async def _fetch_single_api(
-        self, session: aiohttp.ClientSession, source: ApiSourceConfig
-    ) -> list[Relay]:
-        """Fetch and validate relay URLs from a single API endpoint.
-
-        The response format is configurable per source via the ``expression``
-        field on [ApiSourceConfig][bigbrotr.services.finder.ApiSourceConfig].
-
-        Args:
-            session: Shared aiohttp ClientSession for connection pooling.
-            source: API source configuration (URL, timeout, extraction params).
-
-        Returns:
-            Deduplicated list of Relay objects.
+        Loads per-source checkpoints, checks cooldown, fetches relay URLs,
+        and yields ``(relays, checkpoint)`` with updated timestamp on success.
+        Skipped (cooldown) and failed (network error) sources yield nothing.
+        Respects ``request_delay`` between sources and ``is_running`` for
+        graceful shutdown.
         """
-        timeout = aiohttp.ClientTimeout(
-            total=source.timeout,
-            connect=min(source.connect_timeout, source.timeout),
-            sock_read=source.timeout,
-        )
-        async with session.get(source.url, timeout=timeout, ssl=not source.allow_insecure) as resp:
-            resp.raise_for_status()
-            data = await read_bounded_json(resp, self._config.api.max_response_size)
-            return extract_relays_from_response(data, source.expression)
+        source_urls = [s.url for s in sources]
+        checkpoints = await fetch_api_checkpoints(self._brotr, source_urls)
+        checkpoint_map = {cp.key: cp for cp in checkpoints}
+        now = int(time.time())
+
+        async with aiohttp.ClientSession() as session:
+            for i, source in enumerate(sources):
+                if not self.is_running:
+                    return
+
+                cooldown = self._config.api.cooldown
+                last_checked = checkpoint_map[source.url].timestamp
+                if now - last_checked < cooldown:
+                    self._logger.debug(
+                        "api_skipped",
+                        url=source.url,
+                        seconds_left=cooldown - (now - last_checked),
+                    )
+                    continue
+
+                try:
+                    relays = await fetch_api(session, source, self._config.api.max_response_size)
+                    self._logger.debug("api_fetched", url=source.url, count=len(relays))
+                    yield relays, ApiCheckpoint(key=source.url, timestamp=int(time.time()))
+                except (TimeoutError, OSError, aiohttp.ClientError, ValueError) as e:
+                    self._logger.warning(
+                        "api_fetch_failed",
+                        error=str(e),
+                        error_type=type(e).__name__,
+                        url=source.url,
+                    )
+
+                if (
+                    self._config.api.request_delay > 0
+                    and i < len(sources) - 1
+                    and await self.wait(self._config.api.request_delay)
+                ):
+                    return
 
     # ── Event discovery ────────────────────────────────────────────
 
@@ -259,9 +243,10 @@ class Finder(ConcurrentStreamMixin, BaseService[FinderConfig]):
 
         Fetches current cursor positions, scans all relays concurrently
         (bounded by ``events.parallel_relays``) via ``_iter_concurrent()``.
-        Workers yield individual relay URLs. The parent accumulates them in a
-        global buffer flushed at ``brotr.config.batch.max_size`` and saves
-        cursors in batch after each flush.
+        Workers stream event-relay rows. The parent extracts relay URLs,
+        accumulates them in a global buffer flushed at
+        ``brotr.config.batch.max_size``, and saves cursors in batch after
+        each flush.
 
         Returns:
             Number of relay URLs discovered and inserted as candidates.
@@ -269,58 +254,63 @@ class Finder(ConcurrentStreamMixin, BaseService[FinderConfig]):
         if not self._config.events.enabled:
             return 0
 
-        try:
-            cursors = await fetch_event_relay_cursors(self._brotr)
-        except (asyncpg.PostgresError, OSError) as e:
-            self._logger.warning("fetch_cursors_failed", error=str(e), error_type=type(e).__name__)
-            return 0
+        cursors = await fetch_cursors_to_find(self._brotr)
         if not cursors:
             self._logger.debug("no_relays_to_scan")
             return 0
-
-        self._logger.debug("events_scan_started", relay_count=len(cursors))
-
-        self.set_gauge("relays_total", len(cursors))
-        self.set_gauge("relays_scanned", 0)
-        self.set_gauge("event_candidates", 0)
 
         self._event_semaphore = asyncio.Semaphore(self._config.events.parallel_relays)
         self._phase_start = time.monotonic()
 
         total_found = 0
+        rows_seen = 0
         relays_seen: set[str] = set()
         buffer: list[Relay] = []
         pending_cursors: dict[str, FinderCursor] = {}
-        batch_size = self._brotr.config.batch.max_size
+        batch_size = self._config.events.batch_size
 
-        async for relay, cursor in self._iter_concurrent(cursors, self._event_scan_worker):
-            relays_seen.add(cursor.key)
-            buffer.append(relay)
+        self.set_gauge("total_relays", len(cursors))
+        self.set_gauge("rows_seen", rows_seen)
+        self.set_gauge("relays_seen", len(relays_seen))
+
+        self._logger.info("scan_started", relay_count=len(cursors))
+
+        async for relays, cursor in self._iter_concurrent(cursors, self._find_from_events_worker):
+            buffer.extend(relays)
             pending_cursors[cursor.key] = cursor
+            rows_seen += 1
+            self.set_gauge("rows_seen", rows_seen)
+            if cursor.key not in relays_seen:
+                relays_seen.add(cursor.key)
+                self.set_gauge("relays_seen", len(relays_seen))
             if len(buffer) >= batch_size:
-                total_found += await self._flush_event_buffer(buffer, pending_cursors)
-                self.set_gauge("relays_scanned", len(relays_seen))
-                self.set_gauge("event_candidates", total_found)
+                total_found += await insert_relays_as_candidates(self._brotr, buffer)
+                buffer = []
+                await upsert_finder_cursors(self._brotr, pending_cursors.values())
+                pending_cursors = {}
 
-        total_found += await self._flush_event_buffer(buffer, pending_cursors)
-        self.set_gauge("relays_scanned", len(relays_seen))
-        self.set_gauge("event_candidates", total_found)
+        if buffer:
+            total_found += await insert_relays_as_candidates(self._brotr, buffer)
+        if pending_cursors:
+            await upsert_finder_cursors(self._brotr, pending_cursors.values())
 
         self._logger.info(
-            "events_completed",
+            "scan_completed",
             found=total_found,
             relays_scanned=len(relays_seen),
         )
         return total_found
 
-    async def _event_scan_worker(
+    async def _find_from_events_worker(
         self, cursor: FinderCursor
-    ) -> AsyncGenerator[tuple[Relay, FinderCursor], None]:
-        """Stream relay URLs from a single relay's events for ``_iter_concurrent``.
+    ) -> AsyncGenerator[tuple[list[Relay], FinderCursor], None]:
+        """Stream discovered relays from a single source relay for ``_iter_concurrent``.
 
-        Acquires the per-phase semaphore, checks phase duration, and delegates
-        to ``_stream_relay_batches``. On unexpected exception, logs and returns
-        (yields nothing — the relay is silently skipped).
+        Acquires the per-phase semaphore, streams rows via
+        [stream_event_relays][bigbrotr.services.finder.utils.stream_event_relays],
+        extracts relay URLs from tagvalues, and yields ``(relays, cursor)``
+        pairs. On unexpected exception, logs and returns (the relay is silently
+        skipped).
         """
         async with self._event_semaphore:
             if not self.is_running or (
@@ -328,8 +318,19 @@ class Finder(ConcurrentStreamMixin, BaseService[FinderConfig]):
             ):
                 return
             try:
-                async for item in self._stream_relay_batches(cursor):
-                    yield item
+                deadline = time.monotonic() + self._config.events.max_relay_time
+                async for row in stream_event_relays(
+                    self._brotr, cursor, self._config.events.scan_size
+                ):
+                    relays = extract_relays_from_tagvalues([row])
+                    updated = FinderCursor(
+                        key=cursor.key,
+                        timestamp=row["seen_at"],
+                        id=row["event_id"].hex(),
+                    )
+                    yield relays, updated
+                    if time.monotonic() > deadline:
+                        return
             except Exception as e:  # Worker exception boundary — protects TaskGroup
                 self._logger.error(
                     "event_scan_worker_failed",
@@ -337,89 +338,3 @@ class Finder(ConcurrentStreamMixin, BaseService[FinderConfig]):
                     error_type=type(e).__name__,
                     relay=cursor.key,
                 )
-
-    async def _flush_event_buffer(
-        self,
-        buffer: list[Relay],
-        pending_cursors: dict[str, FinderCursor],
-    ) -> int:
-        """Flush the relay buffer and persist pending cursors.
-
-        Args:
-            buffer: Accumulated relay candidates (cleared after flush).
-            pending_cursors: Per-relay cursor positions (cleared after flush).
-
-        Returns:
-            Number of candidates inserted.
-        """
-        inserted = 0
-        if buffer:
-            try:
-                inserted = await insert_relays_as_candidates(self._brotr, list(buffer))
-                self.inc_counter("total_event_candidates", inserted)
-            except (asyncpg.PostgresError, OSError) as e:
-                self._logger.error(
-                    "insert_candidates_failed",
-                    error=str(e),
-                    error_type=type(e).__name__,
-                    count=len(buffer),
-                )
-            buffer.clear()
-        if pending_cursors:
-            try:
-                await save_event_relay_cursors(self._brotr, list(pending_cursors.values()))
-            except (asyncpg.PostgresError, OSError) as e:
-                self._logger.error(
-                    "cursor_update_failed",
-                    error=str(e),
-                    error_type=type(e).__name__,
-                )
-            pending_cursors.clear()
-        return inserted
-
-    async def _stream_relay_batches(
-        self, cursor: FinderCursor
-    ) -> AsyncGenerator[tuple[Relay, FinderCursor], None]:
-        """Stream relay URLs from a single relay using composite cursor pagination.
-
-        Yields ``(relay, updated_cursor)`` for each discovered relay URL.
-        The caller is responsible for buffering and persisting candidates and cursors.
-
-        Args:
-            cursor: [FinderCursor][bigbrotr.services.common.types.FinderCursor]
-                with relay URL and pagination position.
-        """
-        relay_url = cursor.key
-        deadline = time.monotonic() + self._config.events.max_relay_time
-
-        while self.is_running:
-            if time.monotonic() > deadline:
-                break
-
-            try:
-                rows = await scan_event_relay(self._brotr, cursor, self._config.events.batch_size)
-            except (asyncpg.PostgresError, OSError) as e:
-                self._logger.warning(
-                    "relay_event_query_failed",
-                    error=str(e),
-                    error_type=type(e).__name__,
-                    relay=relay_url,
-                )
-                break
-
-            if not rows:
-                break
-
-            relays = extract_relays_from_tagvalues(rows)
-            last_row = rows[-1]
-            cursor = FinderCursor(
-                key=relay_url,
-                timestamp=last_row["seen_at"],
-                id=last_row["event_id"].hex(),
-            )
-
-            for relay in relays:
-                yield relay, cursor
-
-            if len(rows) < self._config.events.batch_size:
-                break

--- a/src/bigbrotr/services/finder/utils.py
+++ b/src/bigbrotr/services/finder/utils.py
@@ -1,19 +1,56 @@
 """Finder service utility functions.
 
-Pure helpers for relay URL extraction from Nostr event data and API responses.
+Helpers for relay URL extraction from Nostr event data and API responses,
+and cursor-paginated streaming of event-relay rows.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import aiohttp
 import jmespath
 
+from bigbrotr.services.common.types import FinderCursor
 from bigbrotr.services.common.utils import parse_relay
+from bigbrotr.utils.http import read_bounded_json
+
+from .queries import scan_event_relay
 
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from bigbrotr.core.brotr import Brotr
     from bigbrotr.models import Relay
+
+    from .configs import ApiSourceConfig
+
+
+async def fetch_api(
+    session: aiohttp.ClientSession,
+    source: ApiSourceConfig,
+    max_response_size: int,
+) -> list[Relay]:
+    """Fetch and validate relay URLs from a single API endpoint.
+
+    Args:
+        session: Shared aiohttp ClientSession for connection pooling.
+        source: API source configuration (URL, timeout, extraction params).
+        max_response_size: Maximum response body size in bytes.
+
+    Returns:
+        Deduplicated list of Relay objects.
+    """
+    timeout = aiohttp.ClientTimeout(
+        total=source.timeout,
+        connect=min(source.connect_timeout, source.timeout),
+        sock_read=source.timeout,
+    )
+    async with session.get(source.url, timeout=timeout, ssl=not source.allow_insecure) as resp:
+        resp.raise_for_status()
+        data = await read_bounded_json(resp, max_response_size)
+        return extract_relays_from_response(data, source.expression)
 
 
 def extract_relays_from_response(data: Any, expression: str) -> list[Relay]:
@@ -44,6 +81,43 @@ def extract_relays_from_response(data: Any, expression: str) -> list[Relay]:
                 seen.add(validated.url)
                 relays.append(validated)
     return relays
+
+
+async def stream_event_relays(
+    brotr: Brotr,
+    cursor: FinderCursor,
+    batch_size: int,
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Stream event-relay rows for a single relay using cursor pagination.
+
+    Fetches rows in batches of *batch_size* via
+    [scan_event_relay][bigbrotr.services.finder.queries.scan_event_relay],
+    advancing the cursor after each batch. Yields individual rows.
+
+    Args:
+        brotr: [Brotr][bigbrotr.core.brotr.Brotr] database interface.
+        cursor: [FinderCursor][bigbrotr.services.common.types.FinderCursor]
+            with relay URL and pagination position.
+        batch_size: Maximum rows per DB query.
+
+    Yields:
+        Event-relay row dicts with ``event_id``, ``tagvalues``, ``seen_at``,
+        and other event columns.
+    """
+    while True:
+        rows = await scan_event_relay(brotr, cursor, batch_size)
+        if not rows:
+            break
+        for row in rows:
+            yield row
+        last = rows[-1]
+        cursor = FinderCursor(
+            key=cursor.key,
+            timestamp=last["seen_at"],
+            id=last["event_id"].hex(),
+        )
+        if len(rows) < batch_size:
+            break
 
 
 def extract_relays_from_tagvalues(rows: list[dict[str, Any]]) -> list[Relay]:

--- a/src/bigbrotr/services/monitor/queries.py
+++ b/src/bigbrotr/services/monitor/queries.py
@@ -235,14 +235,13 @@ async def upsert_publish_checkpoints(brotr: Brotr, state_keys: list[str]) -> Non
         return
     _validate_publish_keys(state_keys)
     now = int(time.time())
-    await brotr.upsert_service_state(
-        [
-            ServiceState(
-                service_name=ServiceName.MONITOR,
-                state_type=ServiceStateType.CHECKPOINT,
-                state_key=key,
-                state_value={"timestamp": now},
-            )
-            for key in state_keys
-        ]
-    )
+    records = [
+        ServiceState(
+            service_name=ServiceName.MONITOR,
+            state_type=ServiceStateType.CHECKPOINT,
+            state_key=key,
+            state_value={"timestamp": now},
+        )
+        for key in state_keys
+    ]
+    await upsert_service_states(brotr, records)

--- a/src/bigbrotr/services/monitor/service.py
+++ b/src/bigbrotr/services/monitor/service.py
@@ -614,7 +614,7 @@ class Monitor(
             chunk_successful: list[tuple[Relay, CheckResult]] = []
             chunk_failed: list[Relay] = []
 
-            async for relay, result in self._iter_concurrent(relays, self._monitoring_worker):
+            async for relay, result in self._iter_concurrent(relays, self._monitor_worker):
                 if result is not None:
                     chunk_successful.append((relay, result))
                     succeeded += 1
@@ -638,7 +638,7 @@ class Monitor(
 
         return succeeded + failed
 
-    async def _monitoring_worker(
+    async def _monitor_worker(
         self, relay: Relay
     ) -> AsyncGenerator[tuple[Relay, CheckResult | None], None]:
         """Health-check a single relay for use with ``_iter_concurrent``.

--- a/src/bigbrotr/services/synchronizer/queries.py
+++ b/src/bigbrotr/services/synchronizer/queries.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from bigbrotr.models.constants import NetworkType, ServiceName
 from bigbrotr.models.service_state import ServiceState, ServiceStateType
+from bigbrotr.services.common.queries import batched_insert, upsert_service_states
 from bigbrotr.services.common.types import SyncCursor
 
 
@@ -117,13 +118,7 @@ async def insert_event_relays(brotr: Brotr, records: list[EventRelay]) -> int:
     Returns:
         Number of new event-relay records inserted.
     """
-    if not records:
-        return 0
-    total = 0
-    batch_size = brotr.config.batch.max_size
-    for i in range(0, len(records), batch_size):
-        total += await brotr.insert_event_relay(records[i : i + batch_size])
-    return total
+    return await batched_insert(brotr, records, brotr.insert_event_relay)
 
 
 async def upsert_sync_cursors(brotr: Brotr, cursors: Iterable[SyncCursor]) -> None:
@@ -149,8 +144,4 @@ async def upsert_sync_cursors(brotr: Brotr, cursors: Iterable[SyncCursor]) -> No
         )
         for cursor in cursors
     ]
-    if not states:
-        return
-    batch_size = brotr.config.batch.max_size
-    for i in range(0, len(states), batch_size):
-        await brotr.upsert_service_state(states[i : i + batch_size])
+    await upsert_service_states(brotr, states)

--- a/src/bigbrotr/services/synchronizer/service.py
+++ b/src/bigbrotr/services/synchronizer/service.py
@@ -177,7 +177,7 @@ class Synchronizer(
 
         self._logger.info("sync_started", relay_count=len(cursors))
 
-        async for event, relay in self._iter_concurrent(cursors, self._sync_worker):
+        async for event, relay in self._iter_concurrent(cursors, self._synchronize_worker):
             buffer.append(EventRelay(event, relay))
             pending_cursors[relay.url] = SyncCursor(
                 key=relay.url,
@@ -212,7 +212,9 @@ class Synchronizer(
 
     # ── Workers ────────────────────────────────────────────────────
 
-    async def _sync_worker(self, cursor: SyncCursor) -> AsyncGenerator[tuple[Event, Relay], None]:
+    async def _synchronize_worker(
+        self, cursor: SyncCursor
+    ) -> AsyncGenerator[tuple[Event, Relay], None]:
         """Stream events from a single relay for use with ``_iter_concurrent``.
 
         Acquires the per-network semaphore, connects to the relay, and streams

--- a/src/bigbrotr/services/validator/service.py
+++ b/src/bigbrotr/services/validator/service.py
@@ -174,7 +174,7 @@ class Validator(ConcurrentStreamMixin, NetworkSemaphoresMixin, BaseService[Valid
             chunk_invalid: list[CandidateCheckpoint] = []
 
             async for candidate, is_valid in self._iter_concurrent(
-                candidates, self._validation_worker
+                candidates, self._validate_worker
             ):
                 if is_valid:
                     chunk_valid.append(candidate)
@@ -197,7 +197,7 @@ class Validator(ConcurrentStreamMixin, NetworkSemaphoresMixin, BaseService[Valid
 
         return validated + not_validated
 
-    async def _validation_worker(
+    async def _validate_worker(
         self, candidate: CandidateCheckpoint
     ) -> AsyncGenerator[tuple[CandidateCheckpoint, bool], None]:
         """Validate a single candidate for use with ``_iter_concurrent``.

--- a/tests/unit/services/test_finder.py
+++ b/tests/unit/services/test_finder.py
@@ -32,15 +32,16 @@ from bigbrotr.services.finder import (
 from bigbrotr.services.finder.queries import (
     delete_stale_api_checkpoints,
     delete_stale_cursors,
-    fetch_event_relay_cursors,
-    load_api_checkpoints,
-    save_api_checkpoints,
-    save_event_relay_cursors,
+    fetch_api_checkpoints,
+    fetch_cursors_to_find,
     scan_event_relay,
+    upsert_api_checkpoints,
+    upsert_finder_cursors,
 )
 from bigbrotr.services.finder.utils import (
     extract_relays_from_response,
     extract_relays_from_tagvalues,
+    fetch_api,
 )
 
 
@@ -62,6 +63,10 @@ def _mock_api_response(data: Any) -> MagicMock:
     return resp
 
 
+def _default_checkpoints(config: FinderConfig) -> list[ApiCheckpoint]:
+    return [ApiCheckpoint(key=s.url, timestamp=0) for s in config.api.sources]
+
+
 @pytest.fixture
 def query_brotr() -> MagicMock:
     brotr = MagicMock()
@@ -75,6 +80,12 @@ def query_brotr() -> MagicMock:
 
 def _make_dict_row(data: dict[str, Any]) -> dict[str, Any]:
     return data
+
+
+async def _mock_stream(*rows: dict[str, Any]) -> AsyncGenerator[dict[str, Any], None]:
+    """Create an async generator that yields the given rows."""
+    for row in rows:
+        yield row
 
 
 # ============================================================================
@@ -563,12 +574,15 @@ class TestFetchFinderCursors:
     async def test_returns_cursor_for_relay_with_state(self, query_brotr: MagicMock) -> None:
         rows = [
             _make_dict_row(
-                {"url": "wss://relay.com", "seen_at": "1700000000", "event_id": "ab" * 32}
+                {
+                    "url": "wss://relay.com",
+                    "state_value": {"timestamp": 1700000000, "id": "ab" * 32},
+                }
             ),
         ]
         query_brotr.fetch = AsyncMock(return_value=rows)
 
-        result = await fetch_event_relay_cursors(query_brotr)
+        result = await fetch_cursors_to_find(query_brotr)
 
         assert len(result) == 1
         cursor = result[0]
@@ -580,11 +594,11 @@ class TestFetchFinderCursors:
         self, query_brotr: MagicMock
     ) -> None:
         rows = [
-            _make_dict_row({"url": "wss://new.relay.com", "seen_at": None, "event_id": None}),
+            _make_dict_row({"url": "wss://new.relay.com", "state_value": None}),
         ]
         query_brotr.fetch = AsyncMock(return_value=rows)
 
-        result = await fetch_event_relay_cursors(query_brotr)
+        result = await fetch_cursors_to_find(query_brotr)
 
         assert len(result) == 1
         cursor = result[0]
@@ -592,29 +606,16 @@ class TestFetchFinderCursors:
         assert cursor.timestamp == 0
         assert cursor.id == "0" * 64
 
-    async def test_invalid_cursor_data_falls_back_to_empty(self, query_brotr: MagicMock) -> None:
-        rows = [
-            _make_dict_row({"url": "wss://corrupt.com", "seen_at": "100", "event_id": "not-hex"}),
-        ]
-        query_brotr.fetch = AsyncMock(return_value=rows)
-
-        result = await fetch_event_relay_cursors(query_brotr)
-
-        assert len(result) == 1
-        cursor = result[0]
-        assert cursor.timestamp == 0
-        assert cursor.id == "0" * 64
-
     async def test_query_uses_left_join(self, query_brotr: MagicMock) -> None:
-        await fetch_event_relay_cursors(query_brotr)
+        await fetch_cursors_to_find(query_brotr)
 
         query_brotr.fetch.assert_awaited_once()
         sql = query_brotr.fetch.call_args[0][0]
-        assert "LEFT JOIN service_state" in sql
+        assert "LEFT JOIN cursors" in sql
         assert "FROM relay" in sql
 
     async def test_empty_database(self, query_brotr: MagicMock) -> None:
-        result = await fetch_event_relay_cursors(query_brotr)
+        result = await fetch_cursors_to_find(query_brotr)
 
         assert result == []
 
@@ -635,7 +636,7 @@ class TestScanEventRelay:
         assert "FROM event e" in sql
         assert "event_relay er" in sql
         assert "relay_url = $1" in sql
-        assert "= 0 OR (er.seen_at, e.id) >" in sql
+        assert "(er.seen_at, e.id) >" in sql
         assert "LIMIT $4" in sql
         assert args[0][1] == "wss://source.relay.com"
         assert args[0][2] == 1700000000
@@ -657,7 +658,7 @@ class TestScanEventRelay:
         assert result == []
 
 
-class TestLoadApiCheckpoints:
+class TestFetchApiCheckpoints:
     async def test_happy_path(self, query_brotr: MagicMock) -> None:
         query_brotr.fetch = AsyncMock(
             return_value=[
@@ -667,14 +668,14 @@ class TestLoadApiCheckpoints:
         )
         urls = ["https://api1.example.com", "https://api2.example.com"]
 
-        result = await load_api_checkpoints(query_brotr, urls)
+        result = await fetch_api_checkpoints(query_brotr, urls)
 
         assert result == [
             ApiCheckpoint(key="https://api1.example.com", timestamp=1700000000),
             ApiCheckpoint(key="https://api2.example.com", timestamp=1700001000),
         ]
 
-    async def test_skips_malformed(self, query_brotr: MagicMock) -> None:
+    async def test_malformed_defaults_to_zero(self, query_brotr: MagicMock) -> None:
         query_brotr.fetch = AsyncMock(
             return_value=[
                 {"state_key": "https://api1.example.com", "state_value": {"timestamp": 1700000000}},
@@ -683,22 +684,41 @@ class TestLoadApiCheckpoints:
         )
         urls = ["https://api1.example.com", "https://api2.example.com"]
 
-        result = await load_api_checkpoints(query_brotr, urls)
+        result = await fetch_api_checkpoints(query_brotr, urls)
 
-        assert result == [ApiCheckpoint(key="https://api1.example.com", timestamp=1700000000)]
+        assert result == [
+            ApiCheckpoint(key="https://api1.example.com", timestamp=1700000000),
+            ApiCheckpoint(key="https://api2.example.com", timestamp=0),
+        ]
 
     async def test_empty_urls(self, query_brotr: MagicMock) -> None:
-        result = await load_api_checkpoints(query_brotr, [])
+        result = await fetch_api_checkpoints(query_brotr, [])
 
         assert result == []
 
-    async def test_no_rows(self, query_brotr: MagicMock) -> None:
+    async def test_missing_url_defaults_to_zero(self, query_brotr: MagicMock) -> None:
         query_brotr.fetch = AsyncMock(return_value=[])
         urls = ["https://api.example.com"]
 
-        result = await load_api_checkpoints(query_brotr, urls)
+        result = await fetch_api_checkpoints(query_brotr, urls)
 
-        assert result == []
+        assert result == [ApiCheckpoint(key="https://api.example.com", timestamp=0)]
+
+    async def test_preserves_url_order(self, query_brotr: MagicMock) -> None:
+        query_brotr.fetch = AsyncMock(
+            return_value=[
+                {"state_key": "https://api2.example.com", "state_value": {"timestamp": 2000}},
+            ]
+        )
+        urls = ["https://api1.example.com", "https://api2.example.com", "https://api3.example.com"]
+
+        result = await fetch_api_checkpoints(query_brotr, urls)
+
+        assert result == [
+            ApiCheckpoint(key="https://api1.example.com", timestamp=0),
+            ApiCheckpoint(key="https://api2.example.com", timestamp=2000),
+            ApiCheckpoint(key="https://api3.example.com", timestamp=0),
+        ]
 
 
 class TestSaveApiCheckpoints:
@@ -709,7 +729,7 @@ class TestSaveApiCheckpoints:
         ]
         query_brotr.upsert_service_state = AsyncMock(return_value=2)
 
-        await save_api_checkpoints(query_brotr, checkpoints)
+        await upsert_api_checkpoints(query_brotr, checkpoints)
 
         query_brotr.upsert_service_state.assert_awaited_once()
         records = query_brotr.upsert_service_state.call_args[0][0]
@@ -729,34 +749,34 @@ class TestSaveFinderCursors:
             FinderCursor(key="wss://relay1.example.com", timestamp=100, id="ab" * 32),
             FinderCursor(key="wss://relay2.example.com", timestamp=200, id="cd" * 32),
         ]
-        await save_event_relay_cursors(query_brotr, cursors)
+        await upsert_finder_cursors(query_brotr, cursors)
 
         query_brotr.upsert_service_state.assert_awaited_once()
         states = query_brotr.upsert_service_state.call_args[0][0]
         assert len(states) == 2
         assert states[0].state_key == "wss://relay1.example.com"
-        assert states[0].state_value["seen_at"] == 100
+        assert states[0].state_value["timestamp"] == 100
         assert states[1].state_key == "wss://relay2.example.com"
-        assert states[1].state_value["seen_at"] == 200
+        assert states[1].state_value["timestamp"] == 200
 
     async def test_blank_cursors_skipped(self, query_brotr: MagicMock) -> None:
         cursors = [
             FinderCursor(key="wss://relay1.example.com"),
             FinderCursor(key="wss://relay2.example.com", timestamp=200, id="cd" * 32),
         ]
-        await save_event_relay_cursors(query_brotr, cursors)
+        await upsert_finder_cursors(query_brotr, cursors)
 
         states = query_brotr.upsert_service_state.call_args[0][0]
         assert len(states) == 1
         assert states[0].state_key == "wss://relay2.example.com"
 
     async def test_all_blank_is_noop(self, query_brotr: MagicMock) -> None:
-        await save_event_relay_cursors(query_brotr, [FinderCursor(key="wss://relay.example.com")])
+        await upsert_finder_cursors(query_brotr, [FinderCursor(key="wss://relay.example.com")])
 
         query_brotr.upsert_service_state.assert_not_awaited()
 
     async def test_empty_list_is_noop(self, query_brotr: MagicMock) -> None:
-        await save_event_relay_cursors(query_brotr, [])
+        await upsert_finder_cursors(query_brotr, [])
 
         query_brotr.upsert_service_state.assert_not_awaited()
 
@@ -856,9 +876,9 @@ class TestFinderFindFromApi:
         )
         finder = Finder(brotr=mock_brotr, config=config)
         with patch(
-            "bigbrotr.services.finder.service.load_api_checkpoints",
+            "bigbrotr.services.finder.service.fetch_api_checkpoints",
             new_callable=AsyncMock,
-            return_value=[],
+            return_value=_default_checkpoints(config),
         ):
             result = await finder.find_from_api()
 
@@ -877,12 +897,12 @@ class TestFinderFindFromApi:
 
         with (
             patch(
-                "bigbrotr.services.finder.service.load_api_checkpoints",
+                "bigbrotr.services.finder.service.fetch_api_checkpoints",
                 new_callable=AsyncMock,
-                return_value={},
+                return_value=_default_checkpoints(config),
             ),
             patch(
-                "bigbrotr.services.finder.service.save_api_checkpoints",
+                "bigbrotr.services.finder.service.upsert_api_checkpoints",
                 new_callable=AsyncMock,
             ) as mock_save,
             patch("aiohttp.ClientSession") as mock_session_cls,
@@ -923,12 +943,12 @@ class TestFinderFindFromApi:
         finder = Finder(brotr=mock_brotr, config=config)
         with (
             patch(
-                "bigbrotr.services.finder.service.load_api_checkpoints",
+                "bigbrotr.services.finder.service.fetch_api_checkpoints",
                 new_callable=AsyncMock,
-                return_value={},
+                return_value=_default_checkpoints(config),
             ),
             patch(
-                "bigbrotr.services.finder.service.save_api_checkpoints",
+                "bigbrotr.services.finder.service.upsert_api_checkpoints",
                 new_callable=AsyncMock,
             ),
             patch("aiohttp.ClientSession") as mock_session_cls,
@@ -955,14 +975,14 @@ class TestFinderFindFromApi:
         finder = Finder(brotr=mock_brotr, config=config)
         with (
             patch(
-                "bigbrotr.services.finder.service.load_api_checkpoints",
+                "bigbrotr.services.finder.service.fetch_api_checkpoints",
                 new_callable=AsyncMock,
                 return_value=[
                     ApiCheckpoint(key="https://api.example.com", timestamp=int(time.time()) - 100)
                 ],
             ),
             patch(
-                "bigbrotr.services.finder.service.save_api_checkpoints",
+                "bigbrotr.services.finder.service.upsert_api_checkpoints",
                 new_callable=AsyncMock,
             ) as mock_save,
         ):
@@ -985,14 +1005,14 @@ class TestFinderFindFromApi:
 
         with (
             patch(
-                "bigbrotr.services.finder.service.load_api_checkpoints",
+                "bigbrotr.services.finder.service.fetch_api_checkpoints",
                 new_callable=AsyncMock,
                 return_value=[
                     ApiCheckpoint(key="https://api.example.com", timestamp=int(time.time()) - 7200)
                 ],
             ),
             patch(
-                "bigbrotr.services.finder.service.save_api_checkpoints",
+                "bigbrotr.services.finder.service.upsert_api_checkpoints",
                 new_callable=AsyncMock,
             ) as mock_save,
             patch("aiohttp.ClientSession") as mock_session_cls,
@@ -1027,18 +1047,20 @@ class TestFinderFindFromApi:
         finder = Finder(brotr=mock_brotr, config=config)
         relay = Relay("wss://relay.com")
 
-        async def _fetch_and_shutdown(session: Any, source: Any) -> list[Relay]:
+        async def _fetch_and_shutdown(
+            session: Any, source: Any, max_response_size: Any
+        ) -> list[Relay]:
             finder.request_shutdown()
             return [relay]
 
         with (
             patch(
-                "bigbrotr.services.finder.service.load_api_checkpoints",
+                "bigbrotr.services.finder.service.fetch_api_checkpoints",
                 new_callable=AsyncMock,
-                return_value=[],
+                return_value=_default_checkpoints(config),
             ),
             patch(
-                "bigbrotr.services.finder.service.save_api_checkpoints",
+                "bigbrotr.services.finder.service.upsert_api_checkpoints",
                 new_callable=AsyncMock,
             ),
             patch("aiohttp.ClientSession") as mock_session_cls,
@@ -1047,7 +1069,7 @@ class TestFinderFindFromApi:
                 new_callable=AsyncMock,
                 return_value=1,
             ),
-            patch.object(finder, "_fetch_single_api", side_effect=_fetch_and_shutdown),
+            patch("bigbrotr.services.finder.service.fetch_api", side_effect=_fetch_and_shutdown),
         ):
             mock_session = MagicMock()
             mock_session.__aenter__ = AsyncMock(return_value=mock_session)
@@ -1074,12 +1096,12 @@ class TestFinderFindFromApi:
 
         with (
             patch(
-                "bigbrotr.services.finder.service.load_api_checkpoints",
+                "bigbrotr.services.finder.service.fetch_api_checkpoints",
                 new_callable=AsyncMock,
-                return_value=[],
+                return_value=_default_checkpoints(config),
             ),
             patch(
-                "bigbrotr.services.finder.service.save_api_checkpoints",
+                "bigbrotr.services.finder.service.upsert_api_checkpoints",
                 new_callable=AsyncMock,
             ),
             patch("aiohttp.ClientSession") as mock_session_cls,
@@ -1088,7 +1110,11 @@ class TestFinderFindFromApi:
                 new_callable=AsyncMock,
                 return_value=1,
             ),
-            patch.object(finder, "_fetch_single_api", new_callable=AsyncMock, return_value=[relay]),
+            patch(
+                "bigbrotr.services.finder.service.fetch_api",
+                new_callable=AsyncMock,
+                return_value=[relay],
+            ) as mock_fetch_api,
         ):
             mock_session = MagicMock()
             mock_session.__aenter__ = AsyncMock(return_value=mock_session)
@@ -1103,7 +1129,7 @@ class TestFinderFindFromApi:
             result = await finder.find_from_api()
 
             assert result == 1
-            assert finder._fetch_single_api.call_count == 1
+            assert mock_fetch_api.call_count == 1
 
     async def test_deduplicates_across_sources(self, mock_brotr: Brotr) -> None:
         config = FinderConfig(
@@ -1129,12 +1155,12 @@ class TestFinderFindFromApi:
 
         with (
             patch(
-                "bigbrotr.services.finder.service.load_api_checkpoints",
+                "bigbrotr.services.finder.service.fetch_api_checkpoints",
                 new_callable=AsyncMock,
-                return_value=[],
+                return_value=_default_checkpoints(config),
             ),
             patch(
-                "bigbrotr.services.finder.service.save_api_checkpoints",
+                "bigbrotr.services.finder.service.upsert_api_checkpoints",
                 new_callable=AsyncMock,
             ),
             patch("aiohttp.ClientSession") as mock_session_cls,
@@ -1167,17 +1193,16 @@ class TestFinderFindFromApi:
         )
         finder = Finder(brotr=mock_brotr, config=config)
         finder.set_gauge = MagicMock()  # type: ignore[method-assign]
-        finder.inc_counter = MagicMock()  # type: ignore[method-assign]
         mock_response = _mock_api_response(["wss://relay1.com", "wss://relay2.com"])
 
         with (
             patch(
-                "bigbrotr.services.finder.service.load_api_checkpoints",
+                "bigbrotr.services.finder.service.fetch_api_checkpoints",
                 new_callable=AsyncMock,
-                return_value={},
+                return_value=_default_checkpoints(config),
             ),
             patch(
-                "bigbrotr.services.finder.service.save_api_checkpoints",
+                "bigbrotr.services.finder.service.upsert_api_checkpoints",
                 new_callable=AsyncMock,
             ),
             patch("aiohttp.ClientSession") as mock_session_cls,
@@ -1195,41 +1220,37 @@ class TestFinderFindFromApi:
 
             await finder.find_from_api()
 
-            finder.set_gauge.assert_any_call("api_candidates", 2)
-            finder.inc_counter.assert_any_call("total_api_candidates", 2)
+            finder.set_gauge.assert_any_call("sources_fetched", 1)
+            finder.set_gauge.assert_any_call("total_sources", 1)
 
 
-class TestFinderFetchSingleApi:
-    async def test_valid_relays(self, mock_brotr: Brotr) -> None:
-        finder = Finder(brotr=mock_brotr)
+class TestFetchApi:
+    async def test_valid_relays(self) -> None:
         source = ApiSourceConfig(url="https://api.example.com", expression="[*]")
 
         mock_response = _mock_api_response(["wss://relay1.com", "wss://relay2.com"])
         mock_session = MagicMock()
         mock_session.get = MagicMock(return_value=mock_response)
 
-        result = await finder._fetch_single_api(mock_session, source)
+        result = await fetch_api(mock_session, source, 5_242_880)
 
         assert len(result) == 2
         result_urls = [r.url for r in result]
         assert "wss://relay1.com" in result_urls
         assert "wss://relay2.com" in result_urls
 
-    async def test_empty_list(self, mock_brotr: Brotr) -> None:
-        finder = Finder(brotr=mock_brotr)
+    async def test_empty_list(self) -> None:
         source = ApiSourceConfig(url="https://api.example.com", expression="[*]")
 
         mock_response = _mock_api_response([])
         mock_session = MagicMock()
         mock_session.get = MagicMock(return_value=mock_response)
 
-        result = await finder._fetch_single_api(mock_session, source)
+        result = await fetch_api(mock_session, source, 5_242_880)
 
         assert len(result) == 0
 
-    async def test_rejects_oversized_response(self, mock_brotr: Brotr) -> None:
-        config = FinderConfig(api=ApiConfig(max_response_size=1024))
-        finder = Finder(brotr=mock_brotr, config=config)
+    async def test_rejects_oversized_response(self) -> None:
         source = ApiSourceConfig(url="https://api.example.com", expression="[*]")
 
         oversized_body = b"x" * 1025
@@ -1245,10 +1266,9 @@ class TestFinderFetchSingleApi:
         mock_session.get = MagicMock(return_value=mock_response)
 
         with pytest.raises(ValueError, match="Response body too large"):
-            await finder._fetch_single_api(mock_session, source)
+            await fetch_api(mock_session, source, 1024)
 
-    async def test_passes_ssl_flag_from_allow_insecure(self, mock_brotr: Brotr) -> None:
-        finder = Finder(brotr=mock_brotr)
+    async def test_passes_ssl_flag_from_allow_insecure(self) -> None:
         source = ApiSourceConfig(
             url="https://api.example.com", expression="[*]", allow_insecure=True
         )
@@ -1257,7 +1277,7 @@ class TestFinderFetchSingleApi:
         mock_session = MagicMock()
         mock_session.get = MagicMock(return_value=mock_response)
 
-        await finder._fetch_single_api(mock_session, source)
+        await fetch_api(mock_session, source, 5_242_880)
 
         _, kwargs = mock_session.get.call_args
         assert kwargs["ssl"] is False
@@ -1273,13 +1293,11 @@ class TestFinderFindFromEvents:
         config = FinderConfig(events=EventsConfig(enabled=False))
         finder = Finder(brotr=mock_brotr, config=config)
         finder.set_gauge = MagicMock()  # type: ignore[method-assign]
-        finder.inc_counter = MagicMock()  # type: ignore[method-assign]
 
         result = await finder.find_from_events()
 
         assert result == 0
         finder.set_gauge.assert_not_called()
-        finder.inc_counter.assert_not_called()
 
     async def test_empty_database_returns_zero(self, mock_brotr: Brotr) -> None:
         mock_brotr._pool.fetch = AsyncMock(return_value=[])  # type: ignore[method-assign]
@@ -1298,34 +1316,27 @@ class TestFinderFindFromEvents:
 
         with (
             patch(
-                "bigbrotr.services.finder.service.fetch_event_relay_cursors", new_callable=AsyncMock
-            ) as mock_get_relays,
-            patch(
-                "bigbrotr.services.finder.service.scan_event_relay",
+                "bigbrotr.services.finder.service.fetch_cursors_to_find",
                 new_callable=AsyncMock,
-            ) as mock_get_events,
+                return_value=[FinderCursor(key="wss://source.relay.com")],
+            ),
+            patch(
+                "bigbrotr.services.finder.service.stream_event_relays",
+                return_value=_mock_stream(mock_event),
+            ),
             patch(
                 "bigbrotr.services.finder.service.insert_relays_as_candidates",
                 new_callable=AsyncMock,
+                return_value=1,
             ) as mock_insert,
         ):
-            mock_get_relays.return_value = [
-                FinderCursor(key="wss://source.relay.com"),
-            ]
-            mock_get_events.side_effect = [[mock_event], []]
-            mock_insert.return_value = 1
-
             mock_brotr.upsert_service_state = AsyncMock(return_value=1)  # type: ignore[method-assign]
 
             finder = Finder(brotr=mock_brotr)
             await finder.find_from_events()
 
             mock_insert.assert_called()
-            all_urls = []
-            for call in mock_insert.call_args_list:
-                relays = call[0][1]
-                for relay in relays:
-                    all_urls.append(relay.url)
+            all_urls = [r.url for call in mock_insert.call_args_list for r in call[0][1]]
             assert any("relay.example.com" in url for url in all_urls)
 
     async def test_cursor_position_updated_after_scan(self, mock_brotr: Brotr) -> None:
@@ -1337,23 +1348,20 @@ class TestFinderFindFromEvents:
 
         with (
             patch(
-                "bigbrotr.services.finder.service.fetch_event_relay_cursors", new_callable=AsyncMock
-            ) as mock_get_relays,
-            patch(
-                "bigbrotr.services.finder.service.scan_event_relay",
+                "bigbrotr.services.finder.service.fetch_cursors_to_find",
                 new_callable=AsyncMock,
-            ) as mock_get_events,
+                return_value=[FinderCursor(key="wss://source.relay.com")],
+            ),
+            patch(
+                "bigbrotr.services.finder.service.stream_event_relays",
+                return_value=_mock_stream(mock_event),
+            ),
             patch(
                 "bigbrotr.services.finder.service.insert_relays_as_candidates",
                 new_callable=AsyncMock,
-            ) as mock_insert,
+                return_value=1,
+            ),
         ):
-            mock_get_relays.return_value = [
-                FinderCursor(key="wss://source.relay.com"),
-            ]
-            mock_get_events.side_effect = [[mock_event], []]
-            mock_insert.return_value = 1
-
             mock_brotr.upsert_service_state = AsyncMock(return_value=1)  # type: ignore[method-assign]
 
             finder = Finder(brotr=mock_brotr)
@@ -1368,22 +1376,6 @@ class TestFinderFindFromEvents:
             )
             assert cursor_saved
 
-    @pytest.mark.parametrize(
-        "error",
-        [OSError("Database connection error"), asyncpg.PostgresError("DB error")],
-        ids=["os_error", "postgres_error"],
-    )
-    async def test_fetch_cursors_failure(self, mock_brotr: Brotr, error: Exception) -> None:
-        with patch(
-            "bigbrotr.services.finder.service.fetch_event_relay_cursors",
-            new_callable=AsyncMock,
-            side_effect=error,
-        ):
-            finder = Finder(brotr=mock_brotr)
-            result = await finder.find_from_events()
-
-            assert result == 0
-
     async def test_buffer_flushed_mid_loop_when_exceeds_batch_size(self, mock_brotr: Brotr) -> None:
         events = [
             {
@@ -1391,34 +1383,18 @@ class TestFinderFindFromEvents:
                 "seen_at": 1700000000 + i,
                 "event_id": bytes([i]) + b"\x00" * 31,
             }
-            for i in range(5)
+            for i in range(25)
         ]
-
-        call_count = 0
-
-        async def _events_side_effect(
-            brotr: Any,
-            cursor: FinderCursor,
-            limit: int,
-        ) -> list[dict[str, Any]]:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return events
-            return []
-
-        mock_brotr.config.batch.max_size = 3
 
         with (
             patch(
-                "bigbrotr.services.finder.service.fetch_event_relay_cursors",
+                "bigbrotr.services.finder.service.fetch_cursors_to_find",
                 new_callable=AsyncMock,
                 return_value=[FinderCursor(key="wss://source.relay.com")],
             ),
             patch(
-                "bigbrotr.services.finder.service.scan_event_relay",
-                new_callable=AsyncMock,
-                side_effect=_events_side_effect,
+                "bigbrotr.services.finder.service.stream_event_relays",
+                return_value=_mock_stream(*events),
             ),
             patch(
                 "bigbrotr.services.finder.service.insert_relays_as_candidates",
@@ -1428,13 +1404,13 @@ class TestFinderFindFromEvents:
         ):
             mock_brotr.upsert_service_state = AsyncMock(return_value=1)  # type: ignore[method-assign]
 
-            finder = Finder(brotr=mock_brotr)
+            config = FinderConfig(events=EventsConfig(batch_size=10))
+            finder = Finder(brotr=mock_brotr, config=config)
             finder.set_gauge = MagicMock()  # type: ignore[method-assign]
-            finder.inc_counter = MagicMock()  # type: ignore[method-assign]
 
             result = await finder.find_from_events()
 
-            assert result == 5
+            assert result == 25
             assert mock_insert.call_count >= 2
 
     async def test_phase_duration_exceeded_stops_workers(self, mock_brotr: Brotr) -> None:
@@ -1446,7 +1422,9 @@ class TestFinderFindFromEvents:
         with patch("time.monotonic", return_value=61.0):
             items = [
                 item
-                async for item in finder._event_scan_worker(FinderCursor(key="wss://relay1.com"))
+                async for item in finder._find_from_events_worker(
+                    FinderCursor(key="wss://relay1.com")
+                )
             ]
 
         assert items == []
@@ -1460,16 +1438,13 @@ class TestFinderFindFromEvents:
 
         with (
             patch(
-                "bigbrotr.services.finder.service.fetch_event_relay_cursors",
+                "bigbrotr.services.finder.service.fetch_cursors_to_find",
                 new_callable=AsyncMock,
-                return_value=[
-                    FinderCursor(key="wss://source.relay.com"),
-                ],
+                return_value=[FinderCursor(key="wss://source.relay.com")],
             ),
             patch(
-                "bigbrotr.services.finder.service.scan_event_relay",
-                new_callable=AsyncMock,
-                side_effect=[[mock_event], []],
+                "bigbrotr.services.finder.service.stream_event_relays",
+                return_value=_mock_stream(mock_event),
             ),
             patch(
                 "bigbrotr.services.finder.service.insert_relays_as_candidates",
@@ -1481,13 +1456,11 @@ class TestFinderFindFromEvents:
 
             finder = Finder(brotr=mock_brotr)
             finder.set_gauge = MagicMock()  # type: ignore[method-assign]
-            finder.inc_counter = MagicMock()  # type: ignore[method-assign]
 
             await finder.find_from_events()
 
-            finder.set_gauge.assert_any_call("event_candidates", 2)
-            finder.set_gauge.assert_any_call("relays_scanned", 1)
-            finder.inc_counter.assert_any_call("total_event_candidates", 2)
+            finder.set_gauge.assert_any_call("rows_seen", 1)
+            finder.set_gauge.assert_any_call("relays_seen", 1)
 
 
 class TestFinderEventScanConcurrency:
@@ -1498,22 +1471,9 @@ class TestFinderEventScanConcurrency:
             "event_id": b"\xab" * 32,
         }
 
-        call_counts: dict[str, int] = {}
-
-        async def _events_side_effect(
-            brotr: Any,
-            cursor: FinderCursor,
-            limit: int,
-        ) -> list[dict[str, Any]]:
-            count = call_counts.get(cursor.key, 0)
-            call_counts[cursor.key] = count + 1
-            if count == 0:
-                return [mock_event]
-            return []
-
         with (
             patch(
-                "bigbrotr.services.finder.service.fetch_event_relay_cursors",
+                "bigbrotr.services.finder.service.fetch_cursors_to_find",
                 new_callable=AsyncMock,
                 return_value=[
                     FinderCursor(key="wss://relay1.com"),
@@ -1522,9 +1482,8 @@ class TestFinderEventScanConcurrency:
                 ],
             ),
             patch(
-                "bigbrotr.services.finder.service.scan_event_relay",
-                new_callable=AsyncMock,
-                side_effect=_events_side_effect,
+                "bigbrotr.services.finder.service.stream_event_relays",
+                side_effect=lambda *_args: _mock_stream(mock_event),
             ),
             patch(
                 "bigbrotr.services.finder.service.insert_relays_as_candidates",
@@ -1539,12 +1498,11 @@ class TestFinderEventScanConcurrency:
             )
             finder = Finder(brotr=mock_brotr, config=config)
             finder.set_gauge = MagicMock()  # type: ignore[method-assign]
-            finder.inc_counter = MagicMock()  # type: ignore[method-assign]
 
             result = await finder.find_from_events()
 
             assert result == 3
-            finder.set_gauge.assert_any_call("relays_scanned", 3)
+            finder.set_gauge.assert_any_call("relays_seen", 3)
 
     async def test_task_failure_does_not_block_others(self, mock_brotr: Brotr) -> None:
         mock_event = {
@@ -1553,20 +1511,18 @@ class TestFinderEventScanConcurrency:
             "event_id": b"\xab" * 32,
         }
 
-        async def _events_side_effect(
+        async def _failing_stream(
             brotr: Any,
             cursor: FinderCursor,
-            limit: int,
-        ) -> list[dict[str, Any]]:
-            if cursor.key == "wss://failing.relay.com" and cursor.timestamp == 0:
+            batch_size: int,
+        ) -> AsyncGenerator[dict[str, Any], None]:
+            if cursor.key == "wss://failing.relay.com":
                 raise asyncpg.PostgresError("simulated DB error")
-            if cursor.timestamp > 0:
-                return []
-            return [mock_event]
+            yield mock_event
 
         with (
             patch(
-                "bigbrotr.services.finder.service.fetch_event_relay_cursors",
+                "bigbrotr.services.finder.service.fetch_cursors_to_find",
                 new_callable=AsyncMock,
                 return_value=[
                     FinderCursor(key="wss://good.relay.com"),
@@ -1574,9 +1530,8 @@ class TestFinderEventScanConcurrency:
                 ],
             ),
             patch(
-                "bigbrotr.services.finder.service.scan_event_relay",
-                new_callable=AsyncMock,
-                side_effect=_events_side_effect,
+                "bigbrotr.services.finder.service.stream_event_relays",
+                side_effect=_failing_stream,
             ),
             patch(
                 "bigbrotr.services.finder.service.insert_relays_as_candidates",
@@ -1588,29 +1543,28 @@ class TestFinderEventScanConcurrency:
 
             finder = Finder(brotr=mock_brotr)
             finder.set_gauge = MagicMock()  # type: ignore[method-assign]
-            finder.inc_counter = MagicMock()  # type: ignore[method-assign]
 
             result = await finder.find_from_events()
 
             assert result == 1
-            finder.set_gauge.assert_any_call("relays_scanned", 1)
+            finder.set_gauge.assert_any_call("relays_seen", 1)
 
     async def test_semaphore_limits_concurrency(self, mock_brotr: Brotr) -> None:
         max_concurrent = 0
         current_concurrent = 0
         lock = asyncio.Lock()
 
-        original_stream = Finder._stream_relay_batches
+        original_worker = Finder._find_from_events_worker
 
-        async def _tracking_stream(
+        async def _tracking_worker(
             self: Any, cursor: FinderCursor
-        ) -> AsyncGenerator[tuple[Any, FinderCursor], None]:
+        ) -> AsyncGenerator[tuple[dict[str, Any], str], None]:
             nonlocal max_concurrent, current_concurrent
             async with lock:
                 current_concurrent += 1
                 max_concurrent = max(max_concurrent, current_concurrent)
             try:
-                async for item in original_stream(self, cursor):
+                async for item in original_worker(self, cursor):
                     yield item
             finally:
                 async with lock:
@@ -1620,41 +1574,40 @@ class TestFinderEventScanConcurrency:
 
         with (
             patch(
-                "bigbrotr.services.finder.service.fetch_event_relay_cursors",
+                "bigbrotr.services.finder.service.fetch_cursors_to_find",
                 new_callable=AsyncMock,
                 return_value=cursors,
             ),
             patch(
-                "bigbrotr.services.finder.service.scan_event_relay",
-                new_callable=AsyncMock,
-                return_value=[],
+                "bigbrotr.services.finder.service.stream_event_relays",
+                side_effect=lambda *_args: _mock_stream(),
             ),
-            patch.object(Finder, "_stream_relay_batches", _tracking_stream),
+            patch.object(Finder, "_find_from_events_worker", _tracking_worker),
         ):
             config = FinderConfig(
                 events=EventsConfig(parallel_relays=3),
             )
             finder = Finder(brotr=mock_brotr, config=config)
             finder.set_gauge = MagicMock()  # type: ignore[method-assign]
-            finder.inc_counter = MagicMock()  # type: ignore[method-assign]
 
             await finder.find_from_events()
 
             assert max_concurrent <= 3
 
     async def test_unexpected_worker_error_logged_not_propagated(self, mock_brotr: Brotr) -> None:
-        async def _failing_events(
+        async def _failing_stream(
             brotr: Any,
             cursor: FinderCursor,
-            limit: int,
-        ) -> list[dict[str, Any]]:
+            batch_size: int,
+        ) -> AsyncGenerator[dict[str, Any], None]:
             if cursor.key == "wss://bad.relay.com":
                 raise RuntimeError("unexpected error")
-            return []
+            return
+            yield  # pragma: no cover
 
         with (
             patch(
-                "bigbrotr.services.finder.service.fetch_event_relay_cursors",
+                "bigbrotr.services.finder.service.fetch_cursors_to_find",
                 new_callable=AsyncMock,
                 return_value=[
                     FinderCursor(key="wss://good.relay.com"),
@@ -1662,118 +1615,17 @@ class TestFinderEventScanConcurrency:
                 ],
             ),
             patch(
-                "bigbrotr.services.finder.service.scan_event_relay",
-                new_callable=AsyncMock,
-                side_effect=_failing_events,
+                "bigbrotr.services.finder.service.stream_event_relays",
+                side_effect=_failing_stream,
             ),
         ):
             finder = Finder(brotr=mock_brotr)
             finder.set_gauge = MagicMock()  # type: ignore[method-assign]
-            finder.inc_counter = MagicMock()  # type: ignore[method-assign]
 
             result = await finder.find_from_events()
 
             assert result == 0
-            finder.set_gauge.assert_any_call("relays_scanned", 0)
-
-
-class TestFlushEventBuffer:
-    async def test_insert_failure_logs_and_clears(self, mock_brotr: Brotr) -> None:
-        from bigbrotr.services.common.utils import parse_relay
-
-        relay = parse_relay("wss://relay.example.com")
-        assert relay is not None
-        buffer = [relay]
-        pending_cursors: dict[str, FinderCursor] = {
-            "wss://source.com": FinderCursor(key="wss://source.com", timestamp=100, id="ab" * 32),
-        }
-
-        with patch(
-            "bigbrotr.services.finder.service.insert_relays_as_candidates",
-            new_callable=AsyncMock,
-            side_effect=asyncpg.PostgresError("insert failed"),
-        ):
-            mock_brotr.upsert_service_state = AsyncMock(return_value=1)  # type: ignore[method-assign]
-            finder = Finder(brotr=mock_brotr)
-            finder.inc_counter = MagicMock()  # type: ignore[method-assign]
-
-            result = await finder._flush_event_buffer(buffer, pending_cursors)
-
-            assert result == 0
-            assert buffer == []
-            assert pending_cursors == {}
-
-    async def test_cursor_save_failure_clears(self, mock_brotr: Brotr) -> None:
-        from bigbrotr.services.common.utils import parse_relay
-
-        relay = parse_relay("wss://relay.example.com")
-        assert relay is not None
-        buffer = [relay]
-        pending_cursors: dict[str, FinderCursor] = {
-            "wss://source.com": FinderCursor(key="wss://source.com", timestamp=100, id="ab" * 32),
-        }
-
-        with patch(
-            "bigbrotr.services.finder.service.insert_relays_as_candidates",
-            new_callable=AsyncMock,
-            return_value=1,
-        ):
-            mock_brotr.upsert_service_state = AsyncMock(  # type: ignore[method-assign]
-                side_effect=asyncpg.PostgresError("cursor save failed"),
-            )
-            finder = Finder(brotr=mock_brotr)
-            finder.inc_counter = MagicMock()  # type: ignore[method-assign]
-
-            result = await finder._flush_event_buffer(buffer, pending_cursors)
-
-            assert result == 1
-            assert buffer == []
-            assert pending_cursors == {}
-
-    async def test_empty_buffer_noop(self, mock_brotr: Brotr) -> None:
-        finder = Finder(brotr=mock_brotr)
-
-        result = await finder._flush_event_buffer([], {})
-
-        assert result == 0
-
-
-class TestStreamRelayBatches:
-    async def test_deadline_exceeded_breaks(self, mock_brotr: Brotr) -> None:
-        config = FinderConfig(events=EventsConfig(max_relay_time=10.0))
-        finder = Finder(brotr=mock_brotr, config=config)
-        finder._is_running = True
-        cursor = FinderCursor(key="wss://relay.com")
-
-        with patch("bigbrotr.services.finder.service.time") as mock_time:
-            mock_time.monotonic.side_effect = [0.0, 11.0]
-
-            results = []
-            async for item in finder._stream_relay_batches(cursor):
-                results.append(item)
-
-            assert results == []
-
-    async def test_query_error_breaks_loop(self, mock_brotr: Brotr) -> None:
-        finder = Finder(brotr=mock_brotr)
-        finder._is_running = True
-        cursor = FinderCursor(key="wss://relay.com")
-
-        with (
-            patch("bigbrotr.services.finder.service.time") as mock_time,
-            patch(
-                "bigbrotr.services.finder.service.scan_event_relay",
-                new_callable=AsyncMock,
-                side_effect=asyncpg.PostgresError("query failed"),
-            ),
-        ):
-            mock_time.monotonic.return_value = 0.0
-
-            results = []
-            async for item in finder._stream_relay_batches(cursor):
-                results.append(item)
-
-            assert results == []
+            finder.set_gauge.assert_any_call("total_relays", 2)
 
 
 # ============================================================================

--- a/tests/unit/services/test_monitor.py
+++ b/tests/unit/services/test_monitor.py
@@ -1287,7 +1287,7 @@ class TestUpsertPublishCheckpoints:
         assert keys == {"announcement", "profile"}
 
     async def test_empty_list_skips(self, query_brotr: MagicMock) -> None:
-        query_brotr.upsert_service_state = AsyncMock()
+        query_brotr.upsert_service_state = AsyncMock(return_value=0)
 
         await upsert_publish_checkpoints(query_brotr, [])
 
@@ -1473,7 +1473,7 @@ class TestMonitoringWorker:
             new_callable=AsyncMock,
             return_value=result,
         ):
-            results = [item async for item in monitor._monitoring_worker(relay)]
+            results = [item async for item in monitor._monitor_worker(relay)]
             r, res = results[0]
 
         assert r is relay
@@ -1491,7 +1491,7 @@ class TestMonitoringWorker:
             new_callable=AsyncMock,
             return_value=empty_result,
         ):
-            results = [item async for item in monitor._monitoring_worker(relay)]
+            results = [item async for item in monitor._monitor_worker(relay)]
             r, res = results[0]
 
         assert r is relay
@@ -1508,7 +1508,7 @@ class TestMonitoringWorker:
             new_callable=AsyncMock,
             side_effect=RuntimeError("connection lost"),
         ):
-            results = [item async for item in monitor._monitoring_worker(relay)]
+            results = [item async for item in monitor._monitor_worker(relay)]
             r, res = results[0]
 
         assert r is relay
@@ -1531,7 +1531,7 @@ class TestMonitoringWorker:
             ),
             pytest.raises(exc_type),
         ):
-            async for _ in monitor._monitoring_worker(relay):
+            async for _ in monitor._monitor_worker(relay):
                 pass
 
 
@@ -1908,7 +1908,7 @@ class TestMonitorMetrics:
         relay2 = Relay("wss://fail.example.com")
         result = _make_check_result(nip66_rtt=_make_rtt_meta(rtt_open=50))
 
-        async def fake_monitoring_worker(relay: Relay):
+        async def fake_monitor_worker(relay: Relay):
             if relay.url == relay1.url:
                 yield (relay, result)
             else:
@@ -1931,7 +1931,7 @@ class TestMonitorMetrics:
                 new_callable=AsyncMock,
                 side_effect=[[relay1, relay2], []],
             ),
-            patch.object(monitor, "_monitoring_worker", side_effect=fake_monitoring_worker),
+            patch.object(monitor, "_monitor_worker", side_effect=fake_monitor_worker),
             patch(
                 "bigbrotr.services.monitor.service.insert_relay_metadata",
                 new_callable=AsyncMock,
@@ -2142,7 +2142,7 @@ class TestCheckRelay:
         relay = Relay("wss://relay.example.com")
         monitor.network_semaphores = {}
 
-        results = [r async for r in monitor._monitoring_worker(relay)]
+        results = [r async for r in monitor._monitor_worker(relay)]
 
         assert len(results) == 1
         assert results[0] == (relay, None)
@@ -2474,7 +2474,7 @@ class TestMonitorMaxRelaysBudget:
                 new_callable=AsyncMock,
                 side_effect=[[relay1, relay2, relay3], []],
             ),
-            patch.object(monitor, "_monitoring_worker", side_effect=fake_worker),
+            patch.object(monitor, "_monitor_worker", side_effect=fake_worker),
             patch(
                 "bigbrotr.services.monitor.service.insert_relay_metadata",
                 new_callable=AsyncMock,
@@ -2519,7 +2519,7 @@ class TestMonitorMaxRelaysBudget:
                 new_callable=AsyncMock,
                 side_effect=[[relay1], []],
             ) as mock_fetch,
-            patch.object(monitor, "_monitoring_worker", side_effect=fake_worker),
+            patch.object(monitor, "_monitor_worker", side_effect=fake_worker),
             patch(
                 "bigbrotr.services.monitor.service.insert_relay_metadata",
                 new_callable=AsyncMock,

--- a/tests/unit/services/test_synchronizer.py
+++ b/tests/unit/services/test_synchronizer.py
@@ -64,7 +64,7 @@ def query_brotr() -> MagicMock:
     brotr.fetchval = AsyncMock(return_value=0)
     brotr.fetch = AsyncMock(return_value=[])
     brotr.insert_event_relay = AsyncMock(return_value=0)
-    brotr.upsert_service_state = AsyncMock(return_value=None)
+    brotr.upsert_service_state = AsyncMock(return_value=0)
     brotr.config.batch.max_size = 1000
     return brotr
 
@@ -456,7 +456,7 @@ class TestSynchronize:
         sync = Synchronizer(brotr=mock_synchronizer_brotr)
         sync.set_gauge = MagicMock()  # type: ignore[method-assign]
 
-        async def fake_sync_worker(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        async def fake_synchronize_worker(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
             yield evt1, relay
             yield evt2, relay
 
@@ -472,7 +472,7 @@ class TestSynchronize:
                 new_callable=AsyncMock,
                 return_value=2,
             ),
-            patch.object(sync, "_sync_worker", side_effect=fake_sync_worker),
+            patch.object(sync, "_synchronize_worker", side_effect=fake_synchronize_worker),
             patch(
                 "bigbrotr.services.synchronizer.service.upsert_sync_cursors",
                 new_callable=AsyncMock,
@@ -500,7 +500,7 @@ class TestSynchronize:
                 new_callable=AsyncMock,
                 return_value=[cursor],
             ),
-            patch.object(sync, "_sync_worker", side_effect=failing_worker),
+            patch.object(sync, "_synchronize_worker", side_effect=failing_worker),
         ):
             result = await sync.synchronize()
 
@@ -514,7 +514,7 @@ class TestSynchronize:
         sync = Synchronizer(brotr=mock_synchronizer_brotr)
         sync.set_gauge = MagicMock()  # type: ignore[method-assign]
 
-        async def fake_sync_worker(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        async def fake_synchronize_worker(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
             yield evt1, relay
 
         with (
@@ -529,7 +529,7 @@ class TestSynchronize:
                 new_callable=AsyncMock,
                 return_value=1,
             ),
-            patch.object(sync, "_sync_worker", side_effect=fake_sync_worker),
+            patch.object(sync, "_synchronize_worker", side_effect=fake_synchronize_worker),
             patch(
                 "bigbrotr.services.synchronizer.service.upsert_sync_cursors",
                 new_callable=AsyncMock,
@@ -548,7 +548,7 @@ class TestSynchronize:
         sync = Synchronizer(brotr=mock_synchronizer_brotr, config=config)
         sync.set_gauge = MagicMock()  # type: ignore[method-assign]
 
-        async def fake_sync_worker(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        async def fake_synchronize_worker(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
             for evt in events:
                 yield evt, relay
 
@@ -564,7 +564,7 @@ class TestSynchronize:
                 "bigbrotr.services.synchronizer.service.insert_event_relays",
                 mock_insert,
             ),
-            patch.object(sync, "_sync_worker", side_effect=fake_sync_worker),
+            patch.object(sync, "_synchronize_worker", side_effect=fake_synchronize_worker),
             patch(
                 "bigbrotr.services.synchronizer.service.upsert_sync_cursors",
                 new_callable=AsyncMock,
@@ -589,7 +589,7 @@ class TestSynchronize:
         sync = Synchronizer(brotr=mock_synchronizer_brotr, config=config)
         sync.set_gauge = MagicMock()  # type: ignore[method-assign]
 
-        async def fake_sync_worker(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        async def fake_synchronize_worker(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
             for evt in events:
                 yield evt, relay
 
@@ -615,7 +615,7 @@ class TestSynchronize:
                 new_callable=AsyncMock,
                 return_value=2,
             ),
-            patch.object(sync, "_sync_worker", side_effect=fake_sync_worker),
+            patch.object(sync, "_synchronize_worker", side_effect=fake_synchronize_worker),
             patch(
                 "bigbrotr.services.synchronizer.service.upsert_sync_cursors",
                 new_callable=AsyncMock,
@@ -638,7 +638,7 @@ class TestSynchronize:
         sync = Synchronizer(brotr=mock_synchronizer_brotr)
         sync.set_gauge = MagicMock()  # type: ignore[method-assign]
 
-        async def fake_sync_worker(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        async def fake_synchronize_worker(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
             yield evt1, relay
 
         with (
@@ -653,7 +653,7 @@ class TestSynchronize:
                 new_callable=AsyncMock,
                 return_value=1,
             ),
-            patch.object(sync, "_sync_worker", side_effect=fake_sync_worker),
+            patch.object(sync, "_synchronize_worker", side_effect=fake_synchronize_worker),
             patch(
                 "bigbrotr.services.synchronizer.service.upsert_sync_cursors",
                 new_callable=AsyncMock,
@@ -673,7 +673,7 @@ class TestSynchronize:
         sync = Synchronizer(brotr=mock_synchronizer_brotr)
         sync.set_gauge = MagicMock()  # type: ignore[method-assign]
 
-        async def fake_sync_worker(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        async def fake_synchronize_worker(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
             yield evt1, relay
             yield evt2, relay
 
@@ -689,7 +689,7 @@ class TestSynchronize:
                 new_callable=AsyncMock,
                 return_value=2,
             ),
-            patch.object(sync, "_sync_worker", side_effect=fake_sync_worker),
+            patch.object(sync, "_synchronize_worker", side_effect=fake_synchronize_worker),
             patch(
                 "bigbrotr.services.synchronizer.service.upsert_sync_cursors",
                 new_callable=AsyncMock,
@@ -702,7 +702,7 @@ class TestSynchronize:
 
 
 # ============================================================================
-# _sync_worker
+# _synchronize_worker
 # ============================================================================
 
 
@@ -712,7 +712,7 @@ class TestSyncWorker:
         sync.network_semaphores = {}
 
         cursor = SyncCursor(key="wss://unknown.relay.com")
-        items = [item async for item in sync._sync_worker(cursor)]
+        items = [item async for item in sync._synchronize_worker(cursor)]
 
         assert items == []
 
@@ -728,7 +728,7 @@ class TestSyncWorker:
             "bigbrotr.services.synchronizer.service.connect_relay",
             new_callable=AsyncMock,
         ) as mock_connect:
-            items = [item async for item in sync._sync_worker(cursor)]
+            items = [item async for item in sync._synchronize_worker(cursor)]
 
         assert items == []
         mock_connect.assert_not_awaited()
@@ -750,7 +750,7 @@ class TestSyncWorker:
             new_callable=AsyncMock,
             side_effect=error,
         ):
-            items = [item async for item in sync._sync_worker(cursor)]
+            items = [item async for item in sync._synchronize_worker(cursor)]
 
         assert items == []
 
@@ -782,7 +782,7 @@ class TestSyncWorker:
                 side_effect=fake_stream,
             ),
         ):
-            items = [item async for item in sync._sync_worker(cursor)]
+            items = [item async for item in sync._synchronize_worker(cursor)]
 
         assert len(items) == 2
         assert items[0][0] is evt_a
@@ -813,7 +813,7 @@ class TestSyncWorker:
                 side_effect=empty_stream,
             ),
         ):
-            items = [item async for item in sync._sync_worker(cursor)]
+            items = [item async for item in sync._synchronize_worker(cursor)]
 
         assert items == []
         mock_client.disconnect.assert_awaited_once()
@@ -852,7 +852,7 @@ class TestSyncWorker:
                 side_effect=error_stream,
             ),
         ):
-            items = [item async for item in sync._sync_worker(cursor)]
+            items = [item async for item in sync._synchronize_worker(cursor)]
 
         assert items == []
 
@@ -880,7 +880,7 @@ class TestSyncWorker:
                 side_effect=empty_stream,
             ),
         ):
-            items = [item async for item in sync._sync_worker(cursor)]
+            items = [item async for item in sync._synchronize_worker(cursor)]
 
         mock_client.shutdown.assert_awaited_once()
         assert items == []
@@ -930,7 +930,7 @@ class TestSyncWorker:
                 side_effect=mock_monotonic,
             ),
         ):
-            items = [item async for item in sync._sync_worker(cursor)]
+            items = [item async for item in sync._synchronize_worker(cursor)]
 
         # Only first event yielded; second was skipped due to deadline
         assert len(items) == 1
@@ -959,7 +959,7 @@ class TestSyncWorker:
                 side_effect=exploding_stream,
             ),
         ):
-            items = [item async for item in sync._sync_worker(cursor)]
+            items = [item async for item in sync._synchronize_worker(cursor)]
 
         assert items == []
 

--- a/tests/unit/services/test_validator.py
+++ b/tests/unit/services/test_validator.py
@@ -53,7 +53,7 @@ _UTILS = "bigbrotr.services.validator.utils"
 def validator_brotr(mock_brotr: Brotr) -> Brotr:
     mock_brotr.insert_relay = AsyncMock()
     mock_brotr.delete_service_state = AsyncMock()
-    mock_brotr.upsert_service_state = AsyncMock()
+    mock_brotr.upsert_service_state = AsyncMock(return_value=0)
     return mock_brotr
 
 
@@ -678,7 +678,7 @@ class TestValidate:
 
 
 # ============================================================================
-# Validator._validation_worker
+# Validator._validate_worker
 # ============================================================================
 
 
@@ -687,20 +687,20 @@ class TestValidationWorker:
         v = Validator(validator_brotr)
         c = _candidate("wss://good.com")
         with patch(f"{_SVC}.validate_candidate", new_callable=AsyncMock, return_value=True):
-            results = [r async for r in v._validation_worker(c)]
+            results = [r async for r in v._validate_worker(c)]
         assert results == [(c, True)]
 
     async def test_invalid_returns_false(self, validator_brotr: Brotr) -> None:
         v = Validator(validator_brotr)
         c = _candidate("wss://bad.com")
         with patch(f"{_SVC}.validate_candidate", new_callable=AsyncMock, return_value=False):
-            results = [r async for r in v._validation_worker(c)]
+            results = [r async for r in v._validate_worker(c)]
         assert results == [(c, False)]
 
     async def test_unknown_network_returns_false(self, validator_brotr: Brotr) -> None:
         v = Validator(validator_brotr)
         c = _candidate(network=NetworkType.UNKNOWN)
-        results = [r async for r in v._validation_worker(c)]
+        results = [r async for r in v._validate_worker(c)]
         assert results == [(c, False)]
 
     async def test_unexpected_error_returns_false(self, validator_brotr: Brotr) -> None:
@@ -711,13 +711,13 @@ class TestValidationWorker:
             new_callable=AsyncMock,
             side_effect=RuntimeError("boom"),
         ):
-            results = [r async for r in v._validation_worker(c)]
+            results = [r async for r in v._validate_worker(c)]
         assert results == [(c, False)]
 
     async def test_clearnet_no_proxy(self, validator_brotr: Brotr) -> None:
         v = Validator(validator_brotr)
         with patch(f"{_SVC}.validate_candidate", new_callable=AsyncMock, return_value=True) as mock:
-            _ = [r async for r in v._validation_worker(_candidate())]
+            _ = [r async for r in v._validate_worker(_candidate())]
         assert mock.call_args[0][1] is None
 
 
@@ -735,7 +735,7 @@ class TestNetworkRouting:
     ) -> tuple[str | None, float]:
         v = Validator(validator_brotr, config=cfg)
         with patch(f"{_SVC}.validate_candidate", new_callable=AsyncMock, return_value=True) as mock:
-            _ = [r async for r in v._validation_worker(candidate)]
+            _ = [r async for r in v._validate_worker(candidate)]
         return mock.call_args[0][1], mock.call_args[0][2]
 
     async def test_clearnet(self, validator_brotr: Brotr) -> None:
@@ -798,13 +798,13 @@ class TestNetworkRouting:
         cfg = ValidatorConfig(processing=ProcessingConfig(allow_insecure=True))
         v = Validator(validator_brotr, config=cfg)
         with patch(f"{_SVC}.validate_candidate", new_callable=AsyncMock, return_value=True) as mock:
-            _ = [r async for r in v._validation_worker(_candidate())]
+            _ = [r async for r in v._validate_worker(_candidate())]
         assert mock.call_args.kwargs["allow_insecure"] is True
 
     async def test_allow_insecure_default_false(self, validator_brotr: Brotr) -> None:
         v = Validator(validator_brotr)
         with patch(f"{_SVC}.validate_candidate", new_callable=AsyncMock, return_value=True) as mock:
-            _ = [r async for r in v._validation_worker(_candidate())]
+            _ = [r async for r in v._validate_worker(_candidate())]
         assert mock.call_args.kwargs["allow_insecure"] is False
 
 


### PR DESCRIPTION
## Summary

- Restructure finder service to match synchronizer's clean architecture: workers yield processed results, parents do pure accumulation
- Extract `stream_event_relays` utility for cursor-paginated DB streaming
- Refactor `find_from_events`: worker yields `(relays, cursor)`, parent accumulates with batch flush
- Refactor `find_from_api`: worker is async generator handling all source iteration internally, yields `(relays, checkpoint)` with updated timestamps
- Split `batch_size` into `scan_size` (DB query limit) and `batch_size` (flush threshold) in `EventsConfig`
- Align JSON `state_value` keys with Python dataclass attributes (`timestamp`/`id` instead of `seen_at`/`event_id`)
- Add default `timestamp=0` to `Checkpoint` base type
- Use common batching utilities (`upsert_service_states`, `batched_insert`) across finder, synchronizer, and monitor queries
- Rename query functions to follow conventions: `fetch_cursors_to_find`, `upsert_api_checkpoints`, `upsert_finder_cursors`
- Standardize worker names across all services: `_find_from_events_worker`, `_find_from_api_worker`, `_validate_worker`, `_monitor_worker`, `_synchronize_worker`
- Align metrics/logs with synchronizer: `set_gauge` only, consistent gauge names (`total_relays`, `rows_seen`, `relays_seen`)
- Remove defensive `try/except` around DB calls in service methods (let `run_forever()` be the exception boundary)

## Test plan

- [x] All 2716 unit tests pass
- [x] ruff lint clean
- [x] mypy strict clean
- [x] Pre-commit hooks pass