### PR TITLE
docs: fix documentation drift across codebase

### DIFF
--- a/deployments/bigbrotr/postgres/init/03_functions_crud.sql
+++ b/deployments/bigbrotr/postgres/init/03_functions_crud.sql
@@ -364,7 +364,7 @@ COMMENT ON FUNCTION relay_metadata_insert_cascade(TEXT [], TEXT [], BIGINT [], B
 
 
 /*
- * service_state_upsert(TEXT[], TEXT[], TEXT[], JSONB[]) -> VOID
+ * service_state_upsert(TEXT[], TEXT[], TEXT[], JSONB[]) -> INTEGER
  *
  * Bulk upsert (insert or replace) service state records. When a record with
  * the same (service_name, state_type, state_key) already exists, its

--- a/deployments/lilbrotr/postgres/init/03_functions_crud.sql
+++ b/deployments/lilbrotr/postgres/init/03_functions_crud.sql
@@ -358,7 +358,7 @@ COMMENT ON FUNCTION relay_metadata_insert_cascade(TEXT [], TEXT [], BIGINT [], B
 
 
 /*
- * service_state_upsert(TEXT[], TEXT[], TEXT[], JSONB[]) -> VOID
+ * service_state_upsert(TEXT[], TEXT[], TEXT[], JSONB[]) -> INTEGER
  *
  * Bulk upsert (insert or replace) service state records. When a record with
  * the same (service_name, state_type, state_key) already exists, its

--- a/docs/how-to/monitoring-setup.md
+++ b/docs/how-to/monitoring-setup.md
@@ -6,7 +6,7 @@ Configure Prometheus metrics collection, Grafana dashboards, and alerting for Bi
 
 ## Overview
 
-Every BigBrotr service exposes a `/metrics` endpoint in Prometheus exposition format. The Docker Compose stack includes Prometheus and Grafana pre-configured, but you can also connect to an external monitoring stack.
+All continuous BigBrotr services expose a `/metrics` endpoint in Prometheus exposition format. Seeder is a one-shot service and does not expose a metrics endpoint. The Docker Compose stack includes Prometheus and Grafana pre-configured, but you can also connect to an external monitoring stack.
 
 ### Metrics Exposed
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -386,7 +386,8 @@ api:
 
 events:
   enabled: true
-  batch_size: 500                            # Events per scanning batch
+  scan_size: 500                             # Rows per paginated DB query
+  batch_size: 500                            # Discovered relays to buffer before flushing
   parallel_relays: 50                        # Concurrent relay event scans
   max_relay_time: 900.0                      # Max seconds per relay (15 min)
   max_duration: 7200.0                       # Max seconds for entire event phase (2 hours)
@@ -412,7 +413,8 @@ events:
 | Field | Type | Default | Range | Description |
 |-------|------|---------|-------|-------------|
 | `events.enabled` | bool | `true` | - | Enable event-based relay discovery |
-| `events.batch_size` | int | `500` | 10-10000 | Events per scanning batch |
+| `events.scan_size` | int | `500` | 10-10000 | Rows per paginated DB query |
+| `events.batch_size` | int | `500` | 10-10000 | Discovered relays to buffer before flushing |
 | `events.parallel_relays` | int | `50` | 1-200 | Maximum concurrent relay event scans |
 | `events.max_relay_time` | float | `900.0` | 10.0-86400.0 | Maximum seconds to scan a single relay |
 | `events.max_duration` | float | `7200.0` | 60.0-86400.0 | Maximum seconds for the entire event scanning phase |

--- a/docs/user-guide/services.md
+++ b/docs/user-guide/services.md
@@ -133,6 +133,7 @@ flowchart TD
 |-------|------|---------|-------------|
 | `events.enabled` | bool | `true` | Enable event-based relay discovery |
 | `events.batch_size` | int | `500` | Events per scanning batch |
+| `events.scan_size` | int | `500` | Rows per paginated DB query (range 10-10000) |
 | `events.parallel_relays` | int | `50` | Maximum concurrent relay event scans |
 | `events.max_relay_time` | float | `900.0` | Maximum seconds to scan a single relay |
 | `events.max_duration` | float | `7200.0` | Maximum seconds for the entire event scanning phase |
@@ -241,6 +242,13 @@ class CheckResult(NamedTuple):
     nip66_http: Nip66HttpMetadata | None
 ```
 
+**Checkpoint tracking:**
+
+The Monitor uses two types of `CHECKPOINT` records in `service_state`:
+
+- **Per-relay monitoring checkpoints** (key = relay URL) -- track when each relay was last checked, used for cleanup of stale entries when relays are removed.
+- **Publishing checkpoints** (key = `"announcement"` or `"profile"`) -- track when the last kind 10166 announcement or kind 0 profile event was published, enforcing the configured minimum interval between publishes.
+
 **Published Nostr events:**
 
 | Kind | Type | Content |
@@ -286,7 +294,7 @@ class CheckResult(NamedTuple):
 flowchart TD
     A["Synchronizer.run()"] --> B["Fetch relays from DB"]
     B --> C["Load cursors from service_state"]
-    C --> D["Shuffle relays<br/><small>prevent thundering herd</small>"]
+    C --> D["Order relays<br/><small>most behind first</small>"]
     D --> E["synchronize()<br/><small>_iter_concurrent + semaphore</small>"]
     E --> F["Per relay:"]
     F --> G["Connect via WebSocket"]
@@ -301,7 +309,7 @@ flowchart TD
 
 ```
 
-1. `run()` delegates to `synchronize()` -- fetch cursors, shuffle, distribute work
+1. `run()` delegates to `synchronize()` -- fetch cursors ordered by sync progress ascending (most behind first), distribute work
 2. `synchronize()` -- `_iter_concurrent()` with `_sync_worker` async generators and per-network semaphores
 3. For each relay: `_sync_relay_events()` connects via WebSocket, streams events using `stream_events()` with data-driven windowing and binary-split fallback for completeness
 4. Events are buffered and batch-inserted via `insert_event_relays()` (cascade insert to `event` + `event_relay`)

--- a/src/bigbrotr/services/common/types.py
+++ b/src/bigbrotr/services/common/types.py
@@ -107,8 +107,8 @@ class Cursor:
     """Composite pagination cursor stored in ``service_state``.
 
     Tracks a position within an ordered stream using a ``(timestamp, id)``
-    pair for deterministic tie-breaking. Both fields must be ``None``
-    (new cursor, scan from beginning) or both set (resumption point).
+    pair for deterministic tie-breaking. Both fields default to sentinel
+    values (``0`` and ``"0" * 64``) representing "scan from beginning".
 
     Subclass per usage to enable type-level disambiguation:
 
@@ -117,8 +117,9 @@ class Cursor:
 
     Attributes:
         key: State key identifying the entity (typically a relay URL).
-        timestamp: Unix timestamp of the last processed record, or None.
-        id: Raw 32-byte ID for deterministic tie-breaking, or None.
+        timestamp: Unix timestamp of the last processed record (default ``0``).
+        id: Hex-encoded 64-char event ID for deterministic tie-breaking
+            (default ``"0" * 64``).
     """
 
     key: str

--- a/tools/templates/sql/base/03_functions_crud.sql.j2
+++ b/tools/templates/sql/base/03_functions_crud.sql.j2
@@ -377,7 +377,7 @@ COMMENT ON FUNCTION relay_metadata_insert_cascade(TEXT [], TEXT [], BIGINT [], B
 
 
 /*
- * service_state_upsert(TEXT[], TEXT[], TEXT[], JSONB[]) -> VOID
+ * service_state_upsert(TEXT[], TEXT[], TEXT[], JSONB[]) -> INTEGER
  *
  * Bulk upsert (insert or replace) service state records. When a record with
  * the same (service_name, state_type, state_key) already exists, its


### PR DESCRIPTION
## Summary

- Fix Cursor docstring in `types.py`: fields default to sentinel values (`0` and `"0" * 64`), not `None` — remove incorrect "must be None" claim
- Fix `service_state_upsert` SQL comment: returns `INTEGER`, not `VOID` (matches actual function signature)
- Regenerate deployed SQL files from corrected Jinja2 template
- Fix Synchronizer docs: remove incorrect "shuffle" claim — cursors are ordered by sync progress ascending
- Add Finder `scan_size` field to configuration and services docs (was completely undocumented)
- Clarify Monitor uses two types of CHECKPOINT records: per-relay monitoring and publishing (`"announcement"` / `"profile"`)
- Clarify Seeder (one-shot) does not expose a metrics endpoint

## Test plan

- [x] `make ci` passes (2722 tests, ruff, mypy, SQL drift check, vulnerability audit)
- [x] `mkdocs build --strict` passes
- [x] All pre-commit hooks pass