### PR TITLE
fix(db): audit and correct database indexes

### DIFF
--- a/deployments/bigbrotr/postgres/init/08_indexes.sql
+++ b/deployments/bigbrotr/postgres/init/08_indexes.sql
@@ -13,15 +13,15 @@
 -- TABLE INDEXES: event
 -- ==========================================================================
 
--- Global timeline queries: ORDER BY created_at DESC LIMIT N
-CREATE INDEX IF NOT EXISTS idx_event_created_at
-ON event USING btree (created_at DESC);
-
--- Kind filtering: WHERE kind = ? or WHERE kind IN (...)
-CREATE INDEX IF NOT EXISTS idx_event_kind
-ON event USING btree (kind);
+-- Global timeline with tie-breaking: ORDER BY created_at DESC, id DESC
+-- Primary read pattern for event consumption. Covers single-column
+-- created_at lookups via leftmost prefix (replaces standalone index).
+-- Supports cursor pagination: WHERE (created_at, id) < ($1, $2)
+CREATE INDEX IF NOT EXISTS idx_event_created_at_id
+ON event USING btree (created_at DESC, id DESC);
 
 -- Kind + timeline: WHERE kind = ? ORDER BY created_at DESC
+-- Also covers kind-only lookups via leftmost prefix
 CREATE INDEX IF NOT EXISTS idx_event_kind_created_at
 ON event USING btree (kind, created_at DESC);
 
@@ -40,11 +40,6 @@ ON event USING btree (pubkey, kind, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_event_tagvalues
 ON event USING gin (tagvalues);
 
--- Cursor-based pagination for the Finder service:
--- WHERE (created_at, id) > ($1, $2) ORDER BY created_at ASC, id ASC
-CREATE INDEX IF NOT EXISTS idx_event_created_at_id
-ON event USING btree (created_at ASC, id ASC);
-
 
 -- ==========================================================================
 -- TABLE INDEXES: event_relay
@@ -53,18 +48,17 @@ ON event USING btree (created_at ASC, id ASC);
 -- efficient B-tree index on event_id as the leftmost column, so no
 -- separate event_id index is needed.
 
--- All events from a relay: WHERE relay_url = ?
-CREATE INDEX IF NOT EXISTS idx_event_relay_relay_url
-ON event_relay USING btree (relay_url);
-
--- Recently discovered events: ORDER BY seen_at DESC
+-- Global seen_at ordering for API queries: ORDER BY seen_at DESC
 CREATE INDEX IF NOT EXISTS idx_event_relay_seen_at
 ON event_relay USING btree (seen_at DESC);
 
--- Synchronizer progress tracking: WHERE relay_url = ? ORDER BY seen_at DESC
--- Enables index-only scans for SELECT MAX(seen_at) WHERE relay_url = ?
-CREATE INDEX IF NOT EXISTS idx_event_relay_relay_url_seen_at
-ON event_relay USING btree (relay_url, seen_at DESC);
+-- Finder cursor pagination: WHERE relay_url = $1
+--   AND (seen_at, event_id) > ($2, $3) ORDER BY seen_at ASC, event_id ASC
+-- Three-column covering index resolves the composite cursor entirely
+-- from the index without joining to event for tie-breaking.
+-- Also covers relay_url-only lookups via leftmost prefix.
+CREATE INDEX IF NOT EXISTS idx_event_relay_relay_url_seen_at_event_id
+ON event_relay USING btree (relay_url, seen_at ASC, event_id ASC);
 
 
 -- ==========================================================================
@@ -91,19 +85,12 @@ ON relay_metadata USING btree (relay_url, metadata_type, generated_at DESC);
 -- TABLE INDEXES: service_state
 -- ==========================================================================
 
--- All data for a service: WHERE service_name = ?
-CREATE INDEX IF NOT EXISTS idx_service_state_service_name
-ON service_state USING btree (service_name);
-
--- Specific state type within a service: WHERE service_name = ? AND state_type = ?
-CREATE INDEX IF NOT EXISTS idx_service_state_service_name_state_type
-ON service_state USING btree (service_name, state_type);
-
 -- Candidate network filtering: WHERE state_value->>'network' = ANY($3)
--- Used by count_candidates() and fetch_candidates() in the Validator service
+-- Used by count_candidates() and fetch_candidates() in the Validator service.
+-- Partial index: only validator checkpoint rows contain the 'network' key.
 CREATE INDEX IF NOT EXISTS idx_service_state_candidate_network
 ON service_state USING btree ((state_value ->> 'network'))
-WHERE service_name = 'validator' AND state_type = 'candidate';
+WHERE service_name = 'validator' AND state_type = 'checkpoint';
 
 
 -- ==========================================================================

--- a/deployments/lilbrotr/postgres/init/08_indexes.sql
+++ b/deployments/lilbrotr/postgres/init/08_indexes.sql
@@ -13,15 +13,15 @@
 -- TABLE INDEXES: event
 -- ==========================================================================
 
--- Global timeline queries: ORDER BY created_at DESC LIMIT N
-CREATE INDEX IF NOT EXISTS idx_event_created_at
-ON event USING btree (created_at DESC);
-
--- Kind filtering: WHERE kind = ? or WHERE kind IN (...)
-CREATE INDEX IF NOT EXISTS idx_event_kind
-ON event USING btree (kind);
+-- Global timeline with tie-breaking: ORDER BY created_at DESC, id DESC
+-- Primary read pattern for event consumption. Covers single-column
+-- created_at lookups via leftmost prefix (replaces standalone index).
+-- Supports cursor pagination: WHERE (created_at, id) < ($1, $2)
+CREATE INDEX IF NOT EXISTS idx_event_created_at_id
+ON event USING btree (created_at DESC, id DESC);
 
 -- Kind + timeline: WHERE kind = ? ORDER BY created_at DESC
+-- Also covers kind-only lookups via leftmost prefix
 CREATE INDEX IF NOT EXISTS idx_event_kind_created_at
 ON event USING btree (kind, created_at DESC);
 
@@ -40,11 +40,6 @@ ON event USING btree (pubkey, kind, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_event_tagvalues
 ON event USING gin (tagvalues);
 
--- Cursor-based pagination for the Finder service:
--- WHERE (created_at, id) > ($1, $2) ORDER BY created_at ASC, id ASC
-CREATE INDEX IF NOT EXISTS idx_event_created_at_id
-ON event USING btree (created_at ASC, id ASC);
-
 
 -- ==========================================================================
 -- TABLE INDEXES: event_relay
@@ -53,18 +48,17 @@ ON event USING btree (created_at ASC, id ASC);
 -- efficient B-tree index on event_id as the leftmost column, so no
 -- separate event_id index is needed.
 
--- All events from a relay: WHERE relay_url = ?
-CREATE INDEX IF NOT EXISTS idx_event_relay_relay_url
-ON event_relay USING btree (relay_url);
-
--- Recently discovered events: ORDER BY seen_at DESC
+-- Global seen_at ordering for API queries: ORDER BY seen_at DESC
 CREATE INDEX IF NOT EXISTS idx_event_relay_seen_at
 ON event_relay USING btree (seen_at DESC);
 
--- Synchronizer progress tracking: WHERE relay_url = ? ORDER BY seen_at DESC
--- Enables index-only scans for SELECT MAX(seen_at) WHERE relay_url = ?
-CREATE INDEX IF NOT EXISTS idx_event_relay_relay_url_seen_at
-ON event_relay USING btree (relay_url, seen_at DESC);
+-- Finder cursor pagination: WHERE relay_url = $1
+--   AND (seen_at, event_id) > ($2, $3) ORDER BY seen_at ASC, event_id ASC
+-- Three-column covering index resolves the composite cursor entirely
+-- from the index without joining to event for tie-breaking.
+-- Also covers relay_url-only lookups via leftmost prefix.
+CREATE INDEX IF NOT EXISTS idx_event_relay_relay_url_seen_at_event_id
+ON event_relay USING btree (relay_url, seen_at ASC, event_id ASC);
 
 
 -- ==========================================================================
@@ -91,19 +85,12 @@ ON relay_metadata USING btree (relay_url, metadata_type, generated_at DESC);
 -- TABLE INDEXES: service_state
 -- ==========================================================================
 
--- All data for a service: WHERE service_name = ?
-CREATE INDEX IF NOT EXISTS idx_service_state_service_name
-ON service_state USING btree (service_name);
-
--- Specific state type within a service: WHERE service_name = ? AND state_type = ?
-CREATE INDEX IF NOT EXISTS idx_service_state_service_name_state_type
-ON service_state USING btree (service_name, state_type);
-
 -- Candidate network filtering: WHERE state_value->>'network' = ANY($3)
--- Used by count_candidates() and fetch_candidates() in the Validator service
+-- Used by count_candidates() and fetch_candidates() in the Validator service.
+-- Partial index: only validator checkpoint rows contain the 'network' key.
 CREATE INDEX IF NOT EXISTS idx_service_state_candidate_network
 ON service_state USING btree ((state_value ->> 'network'))
-WHERE service_name = 'validator' AND state_type = 'candidate';
+WHERE service_name = 'validator' AND state_type = 'checkpoint';
 
 
 -- ==========================================================================

--- a/docs/user-guide/database.md
+++ b/docs/user-guide/database.md
@@ -582,22 +582,19 @@ Refreshes all materialized views in dependency order:
 | Index | Columns | Type | Purpose |
 |-------|---------|------|---------|
 | PK | `id` | BTREE | Primary key |
-| `idx_event_created_at` | `created_at DESC` | BTREE | Global timeline queries |
-| `idx_event_kind` | `kind` | BTREE | Kind filtering |
-| `idx_event_kind_created_at` | `kind, created_at DESC` | BTREE | Kind + timeline |
+| `idx_event_created_at_id` | `created_at DESC, id DESC` | BTREE | Global timeline with cursor pagination (covers created_at-only via prefix) |
+| `idx_event_kind_created_at` | `kind, created_at DESC` | BTREE | Kind + timeline (covers kind-only via leftmost prefix) |
 | `idx_event_pubkey_created_at` | `pubkey, created_at DESC` | BTREE | Author timeline |
 | `idx_event_pubkey_kind_created_at` | `pubkey, kind, created_at DESC` | BTREE | Author + kind + timeline |
 | `idx_event_tagvalues` | `tagvalues` | GIN | Tag containment (`@>`) |
-| `idx_event_created_at_id` | `created_at ASC, id ASC` | BTREE | Cursor-based pagination |
 
 #### event_relay Indexes
 
 | Index | Columns | Type | Purpose |
 |-------|---------|------|---------|
 | PK | `event_id, relay_url` | BTREE | Composite primary key |
-| `idx_event_relay_relay_url` | `relay_url` | BTREE | All events from a relay |
-| `idx_event_relay_seen_at` | `seen_at DESC` | BTREE | Recently discovered events |
-| `idx_event_relay_relay_url_seen_at` | `relay_url, seen_at DESC` | BTREE | Synchronizer cursor progress |
+| `idx_event_relay_seen_at` | `seen_at DESC` | BTREE | Global seen_at ordering for API |
+| `idx_event_relay_relay_url_seen_at_event_id` | `relay_url, seen_at ASC, event_id ASC` | BTREE | Finder cursor pagination (covers relay_url-only via prefix) |
 
 #### relay_metadata Indexes
 
@@ -616,7 +613,7 @@ Refreshes all materialized views in dependency order:
 | `idx_service_state_candidate_network` | `state_value ->> 'network'` (partial) | BTREE | Validator: filter candidates by network |
 
 !!! note
-    The partial index on `service_state` has a WHERE clause: `WHERE service_name = 'validator' AND state_type = 'candidate'`.
+    The partial index on `service_state` has a WHERE clause: `WHERE service_name = 'validator' AND state_type = 'checkpoint'`. Only validator checkpoint rows contain the `network` key in their `state_value` JSONB.
 
 ### Materialized View Indexes
 

--- a/tools/templates/sql/base/08_indexes.sql.j2
+++ b/tools/templates/sql/base/08_indexes.sql.j2
@@ -16,15 +16,15 @@
 -- ==========================================================================
 
 {% block event_indexes %}
--- Global timeline queries: ORDER BY created_at DESC LIMIT N
-CREATE INDEX IF NOT EXISTS idx_event_created_at
-ON event USING btree (created_at DESC);
-
--- Kind filtering: WHERE kind = ? or WHERE kind IN (...)
-CREATE INDEX IF NOT EXISTS idx_event_kind
-ON event USING btree (kind);
+-- Global timeline with tie-breaking: ORDER BY created_at DESC, id DESC
+-- Primary read pattern for event consumption. Covers single-column
+-- created_at lookups via leftmost prefix (replaces standalone index).
+-- Supports cursor pagination: WHERE (created_at, id) < ($1, $2)
+CREATE INDEX IF NOT EXISTS idx_event_created_at_id
+ON event USING btree (created_at DESC, id DESC);
 
 -- Kind + timeline: WHERE kind = ? ORDER BY created_at DESC
+-- Also covers kind-only lookups via leftmost prefix
 CREATE INDEX IF NOT EXISTS idx_event_kind_created_at
 ON event USING btree (kind, created_at DESC);
 
@@ -42,11 +42,6 @@ ON event USING btree (pubkey, kind, created_at DESC);
 -- Requires the btree_gin extension for GIN support on text arrays
 CREATE INDEX IF NOT EXISTS idx_event_tagvalues
 ON event USING gin (tagvalues);
-
--- Cursor-based pagination for the Finder service:
--- WHERE (created_at, id) > ($1, $2) ORDER BY created_at ASC, id ASC
-CREATE INDEX IF NOT EXISTS idx_event_created_at_id
-ON event USING btree (created_at ASC, id ASC);
 {% endblock %}
 
 
@@ -58,18 +53,17 @@ ON event USING btree (created_at ASC, id ASC);
 -- efficient B-tree index on event_id as the leftmost column, so no
 -- separate event_id index is needed.
 
--- All events from a relay: WHERE relay_url = ?
-CREATE INDEX IF NOT EXISTS idx_event_relay_relay_url
-ON event_relay USING btree (relay_url);
-
--- Recently discovered events: ORDER BY seen_at DESC
+-- Global seen_at ordering for API queries: ORDER BY seen_at DESC
 CREATE INDEX IF NOT EXISTS idx_event_relay_seen_at
 ON event_relay USING btree (seen_at DESC);
 
--- Synchronizer progress tracking: WHERE relay_url = ? ORDER BY seen_at DESC
--- Enables index-only scans for SELECT MAX(seen_at) WHERE relay_url = ?
-CREATE INDEX IF NOT EXISTS idx_event_relay_relay_url_seen_at
-ON event_relay USING btree (relay_url, seen_at DESC);
+-- Finder cursor pagination: WHERE relay_url = $1
+--   AND (seen_at, event_id) > ($2, $3) ORDER BY seen_at ASC, event_id ASC
+-- Three-column covering index resolves the composite cursor entirely
+-- from the index without joining to event for tie-breaking.
+-- Also covers relay_url-only lookups via leftmost prefix.
+CREATE INDEX IF NOT EXISTS idx_event_relay_relay_url_seen_at_event_id
+ON event_relay USING btree (relay_url, seen_at ASC, event_id ASC);
 {% endblock %}
 
 
@@ -98,19 +92,12 @@ ON relay_metadata USING btree (relay_url, metadata_type, generated_at DESC);
 -- TABLE INDEXES: service_state
 -- ==========================================================================
 
--- All data for a service: WHERE service_name = ?
-CREATE INDEX IF NOT EXISTS idx_service_state_service_name
-ON service_state USING btree (service_name);
-
--- Specific state type within a service: WHERE service_name = ? AND state_type = ?
-CREATE INDEX IF NOT EXISTS idx_service_state_service_name_state_type
-ON service_state USING btree (service_name, state_type);
-
 -- Candidate network filtering: WHERE state_value->>'network' = ANY($3)
--- Used by count_candidates() and fetch_candidates() in the Validator service
+-- Used by count_candidates() and fetch_candidates() in the Validator service.
+-- Partial index: only validator checkpoint rows contain the 'network' key.
 CREATE INDEX IF NOT EXISTS idx_service_state_candidate_network
 ON service_state USING btree ((state_value ->> 'network'))
-WHERE service_name = 'validator' AND state_type = 'candidate';
+WHERE service_name = 'validator' AND state_type = 'checkpoint';
 {% endblock %}
 
 


### PR DESCRIPTION
## Summary

### Index audit
- Fix dead partial index `idx_service_state_candidate_network`: predicate used `state_type = 'candidate'` (nonexistent enum value) instead of `'checkpoint'` — the index never matched any rows
- Merge `idx_event_created_at` + `idx_event_created_at_id` into single `(created_at DESC, id DESC)` matching the primary read pattern
- Replace `idx_event_relay_relay_url` + `idx_event_relay_relay_url_seen_at` with covering index `(relay_url, seen_at ASC, event_id ASC)` — resolves the Finder's composite cursor entirely from the index
- Remove `idx_event_kind`: redundant with `idx_event_kind_created_at` leftmost prefix
- Remove `idx_service_state_service_name` and `idx_service_state_service_name_state_type`: redundant with composite PK
- Index count: 31 → 25 (16 table → 10, 15 matview unchanged)

### Refresher interval
- Change `RefresherConfig.interval` default from 3600s (hourly) to 86400s (daily) — matview refreshes are expensive full-table aggregations
- Remove misleading "Hourly"/"Daily" frequency labels from SQL template comments — refresh frequency is controlled by service config, not schema

## Test plan

- [x] `make ci` passes (2722 tests, ruff, mypy, SQL drift check, audit)
- [x] All pre-commit hooks pass