### PR TITLE
docs: improve README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/python-3.11+-3776AB?style=for-the-badge&logo=python&logoColor=white" alt="Python 3.11+">
-  <img src="https://img.shields.io/badge/postgresql-16+-4169E1?style=for-the-badge&logo=postgresql&logoColor=white" alt="PostgreSQL 16+">
-  <img src="https://img.shields.io/badge/async-asyncpg-00ADD8?style=for-the-badge" alt="Async">
-  <img src="https://img.shields.io/badge/docker-compose-2496ED?style=for-the-badge&logo=docker&logoColor=white" alt="Docker">
-  <img src="https://img.shields.io/badge/license-MIT-green?style=for-the-badge" alt="MIT License">
-  <a href="https://codecov.io/gh/Bigbrotr/bigbrotr"><img src="https://img.shields.io/codecov/c/github/Bigbrotr/bigbrotr?token=LM9D3ABW0L&style=for-the-badge&logo=codecov&logoColor=white&label=coverage" alt="Coverage"></a>
-  <a href="https://bigbrotr.github.io/bigbrotr/"><img src="https://img.shields.io/badge/docs-latest-brightgreen?style=for-the-badge&logo=readthedocs&logoColor=white" alt="Documentation"></a>
+  <a href="https://github.com/BigBrotr/bigbrotr/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/BigBrotr/bigbrotr/ci.yml?branch=develop&label=CI&logo=github" alt="CI"></a>
+  <a href="https://github.com/BigBrotr/bigbrotr/actions/workflows/codeql.yml"><img src="https://img.shields.io/github/actions/workflow/status/BigBrotr/bigbrotr/codeql.yml?branch=develop&label=CodeQL&logo=github" alt="CodeQL"></a>
+  <a href="https://codecov.io/gh/Bigbrotr/bigbrotr"><img src="https://img.shields.io/codecov/c/github/Bigbrotr/bigbrotr?token=LM9D3ABW0L&logo=codecov&label=coverage" alt="Coverage"></a>
+  <a href="https://bigbrotr.github.io/bigbrotr/"><img src="https://img.shields.io/badge/docs-latest-blue?logo=readthedocs&logoColor=white" alt="Docs"></a>
+  <img src="https://img.shields.io/badge/python-3.11+-3776AB?logo=python&logoColor=white" alt="Python 3.11+">
+  <img src="https://img.shields.io/badge/postgresql-16-4169E1?logo=postgresql&logoColor=white" alt="PostgreSQL 16">
+  <a href="https://github.com/BigBrotr/bigbrotr/blob/main/LICENSE"><img src="https://img.shields.io/github/license/BigBrotr/bigbrotr" alt="License"></a>
 </p>
 
 <h1 align="center">BigBrotr</h1>


### PR DESCRIPTION
## Summary

- Replace `for-the-badge` style with `flat` badges for a cleaner look
- Add CI and CodeQL workflow status badges (live, linked to Actions)
- Remove generic badges (async, docker) that add no information
- Use dynamic license badge from GitHub API instead of static
- Reorder: status (CI, CodeQL, coverage, docs) then tech (Python, PG) then license

## Test plan

- [x] Verify badge rendering on GitHub