### PR TITLE
fix: disable IPv6 on Docker bridge networks

### DIFF
--- a/deployments/bigbrotr/docker-compose.yaml
+++ b/deployments/bigbrotr/docker-compose.yaml
@@ -770,9 +770,11 @@ networks:
   bigbrotr-data-network:
     driver: bridge
     name: bigbrotr-data-network
+    enable_ipv6: false
   bigbrotr-monitoring-network:
     driver: bridge
     name: bigbrotr-monitoring-network
+    enable_ipv6: false
 
 # ============================================================================
 # USAGE

--- a/deployments/lilbrotr/docker-compose.yaml
+++ b/deployments/lilbrotr/docker-compose.yaml
@@ -770,9 +770,11 @@ networks:
   lilbrotr-data-network:
     driver: bridge
     name: lilbrotr-data-network
+    enable_ipv6: false
   lilbrotr-monitoring-network:
     driver: bridge
     name: lilbrotr-monitoring-network
+    enable_ipv6: false
 
 # ============================================================================
 # USAGE


### PR DESCRIPTION
## Summary
- Disable IPv6 on both Docker bridge networks (data + monitoring) for bigbrotr and lilbrotr deployments
- Containers prefer IPv6 (RFC 6724) when AAAA records are available, but hosts without functional IPv6 connectivity fail with "Network is unreachable" for relays behind dual-stack CDNs (e.g. Cloudflare)

## Test plan
- [ ] `docker compose down && docker compose up -d` — verify networks recreated with IPv6 disabled
- [ ] Confirm services can connect to relays that previously failed (e.g. Cloudflare-fronted domains)