### PR TITLE
fix: refresh relay_metadata_latest before relay_stats in integration test

### DIFF
--- a/tests/integration/base/test_materialized_views.py
+++ b/tests/integration/base/test_materialized_views.py
@@ -301,6 +301,7 @@ class TestRelayStats:
             {"name": "Test Relay", "software": "strfry", "version": "1.0.0"},
         )
         await brotr.insert_relay_metadata([rm], cascade=True)
+        await brotr.refresh_materialized_view("relay_metadata_latest")
         await brotr.refresh_materialized_view("relay_stats")
 
         rows = await brotr.fetch(


### PR DESCRIPTION
## Summary
- Add `relay_metadata_latest` refresh before `relay_stats` refresh in `test_nip11_info_fields`
- The matview optimization (#378) changed `relay_stats` to JOIN `relay_metadata_latest` instead of using a LATERAL subquery, so the dependency view must be refreshed first

## Test plan
- [ ] Integration tests pass (specifically `TestRelayStats::test_nip11_info_fields`)